### PR TITLE
fix(interactive): fix selection not working after search input

### DIFF
--- a/src/features/interactive/search-prompt.test.ts
+++ b/src/features/interactive/search-prompt.test.ts
@@ -53,10 +53,8 @@ describe("createChoices", () => {
     const choices = createChoices(results, 80);
 
     expect(choices).toHaveLength(1);
-    // name contains JSON (Enquirer returns name on selection)
+    // name contains JSON (Enquirer returns name on selection when value is not defined)
     expect(JSON.parse(choices[0].name).item.id).toBe("ref-001");
-    // value contains the reference id for debugging
-    expect(choices[0].value).toBe("ref-001");
   });
 
   it("includes formatted message with index starting at 1", () => {
@@ -83,8 +81,6 @@ describe("createChoices", () => {
     const parsed = JSON.parse(choices[0].name as string);
     expect(parsed.index).toBe(0);
     expect(parsed.item.id).toBe("ref-001");
-    // value stores the reference id for debugging
-    expect(choices[0].value).toBe("ref-001");
   });
 
   it("handles multiple results with correct indices", () => {


### PR DESCRIPTION
## Summary

- Fixed interactive search selection not working after entering search text
- Resolved "No items were selected" error when selecting items after filtering

## Changes

1. **Removed `value` property from choices** - Enquirer returns `value` instead of `name` when defined, causing `parseSelectedValues` to fail on non-JSON strings

2. **Added workaround for Enquirer bug** - Focused item with `enabled=true` is not included in result array. Now checks `prompt.focused` when result is empty

3. **Preserve selection state during search** - Track enabled item IDs and restore them when suggest callback updates choices

## Test plan

- [ ] Run `node ./bin/reference-manager.js search -i`
- [ ] Enter search text to filter results
- [ ] Select first item with space + enter → should work now
- [ ] Select other items with space + enter → should continue to work
- [ ] Select without entering search text → should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)