### PR TITLE
fix(parser): make custom metadata fields optional in schema

### DIFF
--- a/src/core/csl-json/types.ts
+++ b/src/core/csl-json/types.ts
@@ -26,11 +26,14 @@ const CslFulltextSchema = z.object({
 });
 
 // CSL-JSON Custom Metadata
+// uuid, created_at, timestamp are optional in schema because:
+// 1. Other software (e.g., Zotero) may set custom fields without these
+// 2. Missing fields are auto-populated by ensureCustomMetadata() after parsing
 const CslCustomSchema = z
   .object({
-    uuid: z.string(),
-    created_at: z.string(),
-    timestamp: z.string(),
+    uuid: z.string().optional(),
+    created_at: z.string().optional(),
+    timestamp: z.string().optional(),
     additional_urls: z.array(z.string()).optional(),
     fulltext: CslFulltextSchema.optional(),
     tags: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary

- Make `uuid`, `created_at`, and `timestamp` fields optional in `CslCustomSchema`
- This allows CSL-JSON files with incomplete `custom` objects to be parsed successfully
- Missing fields are auto-populated by `ensureCustomMetadata()` after validation

## Problem

When a CSL-JSON file contained a `custom` object without all required fields (e.g., files exported from Zotero or other reference managers), the parser would fail with validation errors like:

```
Error: Invalid CSL-JSON structure: [
  {
    "expected": "string",
    "code": "invalid_type",
    "path": [0, "custom", "uuid"],
    "message": "Invalid input: expected string, received undefined"
  }
]
```

## Solution

Changed the Zod schema to make these fields optional:

```typescript
// Before
uuid: z.string(),
created_at: z.string(),
timestamp: z.string(),

// After
uuid: z.string().optional(),
created_at: z.string().optional(),
timestamp: z.string().optional(),
```

The `ensureCustomMetadata()` function already handles auto-populating these fields after parsing, so this change simply allows the validation to pass.

## Test plan

- [x] All existing tests pass (1972 tests)
- [x] Verified that incomplete `custom` objects are now accepted and auto-populated
- [x] Verified that other validation errors (missing `id`, `type`, invalid formats) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)