### PR TITLE
fix(cite): apply config default_style and csl_directory settings

### DIFF
--- a/src/cli/execution-context.test.ts
+++ b/src/cli/execution-context.test.ts
@@ -28,6 +28,12 @@ describe("execution-context", () => {
       autoStart: false,
       autoStopMinutes: 0,
     },
+    citation: {
+      defaultStyle: "apa",
+      cslDirectory: [],
+      defaultLocale: "en-US",
+      defaultFormat: "text",
+    },
   };
 
   const mockLibrary = {

--- a/src/cli/execution-context.ts
+++ b/src/cli/execution-context.ts
@@ -70,6 +70,6 @@ export async function createExecutionContext(
   const library = await loadLibrary(config.library);
   return {
     mode: "local",
-    library: new OperationsLibrary(library),
+    library: new OperationsLibrary(library, config.citation),
   };
 }

--- a/src/config/csl-styles.test.ts
+++ b/src/config/csl-styles.test.ts
@@ -294,6 +294,40 @@ describe("CSL Style Management", () => {
         expect(result.styleName).toBe("custom");
         expect(result.styleXml).toBe(mockCSL);
       });
+
+      it("should use default_style from csl_directory when style is not specified", () => {
+        const mockCSL = '<?xml version="1.0"?><style>nature</style>';
+        vi.mocked(fs.existsSync).mockImplementation((p) => {
+          return p === path.join("/home/user/.csl", "nature.csl");
+        });
+        vi.mocked(fs.readFileSync).mockReturnValue(mockCSL);
+
+        // default_style is "nature" which is not a built-in style
+        // It should be found in csl_directory
+        const result = resolveStyle({
+          defaultStyle: "nature",
+          cslDirectory: "/home/user/.csl",
+        });
+
+        expect(result.type).toBe("custom");
+        expect(result.styleName).toBe("nature");
+        expect(result.styleXml).toBe(mockCSL);
+      });
+
+      it("should fall back to apa when default_style CSL file not found in csl_directory", () => {
+        vi.mocked(fs.existsSync).mockReturnValue(false);
+
+        // default_style is "nature" which is not a built-in style
+        // and not found in csl_directory
+        const result = resolveStyle({
+          defaultStyle: "nature",
+          cslDirectory: "/home/user/.csl",
+        });
+
+        // Should fall back to apa
+        expect(result.type).toBe("builtin");
+        expect(result.styleName).toBe("apa");
+      });
     });
   });
 

--- a/src/mcp/context.ts
+++ b/src/mcp/context.ts
@@ -34,7 +34,7 @@ export async function createMcpContext(options: CreateMcpContextOptions): Promis
   const library = await Library.load(libraryPath);
 
   // Wrap library with OperationsLibrary for ILibraryOperations interface
-  const libraryOperations = new OperationsLibrary(library);
+  const libraryOperations = new OperationsLibrary(library, config.citation);
 
   // Create and start file watcher
   const fileWatcher = new FileWatcher(libraryPath, {


### PR DESCRIPTION
## Summary
- Fix `cite` operation to correctly apply `default_style` and `csl_directory` from config file
- Pass `CitationConfig` to `OperationsLibrary` for default style resolution
- Propagate citation config in both CLI and MCP contexts

## Test plan
- [x] All existing tests pass
- [x] Added tests for merging citationConfig with cite options
- [x] Verified explicit options override config defaults
- [x] Added tests for resolving default_style from csl_directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)