### PR TITLE
feat: add readChoice CLI helper for numbered selection prompts

### DIFF
--- a/spec/tasks/20260202-01-sync-interactive-role-assignment.md
+++ b/spec/tasks/20260202-01-sync-interactive-role-assignment.md
@@ -137,8 +137,8 @@ Behavior:
 - Default to `defaultIndex` on empty input (Enter)
 - Non-TTY: return default choice value
 
-- [ ] Implement: `readChoice` in `src/cli/helpers.ts`
-- [ ] Lint/Type check
+- [x] Implement: `readChoice` in `src/cli/helpers.ts`
+- [x] Lint/Type check
 
 ### Step 4: Interactive Role Assignment in `attach sync` (TTY)
 


### PR DESCRIPTION
## Summary

- Add `readChoice` function to `src/cli/helpers.ts` — a readline-based numbered choice prompt for role selection
- Follows the same pattern as existing `readConfirmation` (stderr output, TTY detection, Ink raw-mode recovery)
- Non-TTY mode returns the default choice value immediately
- Invalid or empty input falls back to the default selection

## Context

This is **Step 3** of the sync interactive role assignment task (`spec/tasks/20260202-01-sync-interactive-role-assignment.md`). The `readChoice` helper will be used by later steps to prompt users to assign roles to files with non-standard filenames during `ref attach sync`.

## Test plan

- [x] TypeScript type check passes (`npm run typecheck`)
- [x] Biome lint passes (`npm run lint`)
- [x] All 2589 existing tests pass (`npm test`)
- [ ] Manual TTY test: import `readChoice` and verify numbered list display + selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)