### PR TITLE
feat: add suggestRoleFromContext and roleOverrides for sync

### DIFF
--- a/spec/tasks/20260202-01-sync-interactive-role-assignment.md
+++ b/spec/tasks/20260202-01-sync-interactive-role-assignment.md
@@ -103,16 +103,16 @@ Changes:
 - In `buildUpdatedFiles`, when adding new files, check for overrides and apply them
 - Ensure overrides only apply when `yes: true` (i.e., when actually applying changes)
 
-- [ ] Write test: `src/features/operations/attachments/sync.test.ts`
+- [x] Write test: `src/features/operations/attachments/sync.test.ts`
   - Sync with overrides applied: verify metadata uses overridden role/label
   - Override only specific files (some overridden, others keep inferred role)
   - Overrides ignored in dry-run mode
   - Override with non-existent filename (ignored gracefully)
-- [ ] Create stub: extend `SyncAttachmentOptions` interface, add override logic placeholder
-- [ ] Verify Red
-- [ ] Implement
-- [ ] Verify Green
-- [ ] Lint/Type check
+- [x] Create stub: extend `SyncAttachmentOptions` interface, add override logic placeholder
+- [x] Verify Red
+- [x] Implement
+- [x] Verify Green
+- [x] Lint/Type check
 
 ### Step 3: Add `readChoice` CLI Helper
 


### PR DESCRIPTION
## Summary

- Add `suggestRoleFromContext()` pure function that suggests roles for unknown files based on existing attachments and file extension (fulltext/supplement/null)
- Add `roleOverrides` option to `SyncAttachmentOptions` allowing callers to override inferred roles for specific files during sync
- These are the operation-layer building blocks (Steps 1-2) for interactive role assignment; CLI-layer integration (Steps 3-7) will follow in a separate PR

## Test plan

- [x] 12 unit tests for `suggestRoleFromContext` covering all condition rows and edge cases
- [x] 5 unit tests for `roleOverrides` (apply overrides, partial overrides, dry-run ignored, non-existent filename, role-only without label)
- [x] All 2606 existing tests pass (no regressions)
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)