### PR TITLE
feat: interactive role assignment in attach open flow (Step 33.5)

### DIFF
--- a/spec/tasks/20260202-01-sync-interactive-role-assignment.md
+++ b/spec/tasks/20260202-01-sync-interactive-role-assignment.md
@@ -208,12 +208,12 @@ Changes:
 - Change to: dry-run first → check for `other` roles → prompt if needed → apply with overrides
 - Extract shared logic with `runInteractiveSyncMode` into a helper (e.g., `promptForUnknownRoles`)
 
-- [ ] Write test: `src/cli/commands/attach.test.ts`
+- [x] Write test: `src/cli/commands/attach.test.ts`
   - Test that `attach open` interactive mode prompts for unknown roles
   - Test that files matching convention are auto-accepted
-- [ ] Implement
-- [ ] Verify Green
-- [ ] Lint/Type check
+- [x] Implement
+- [x] Verify Green
+- [x] Lint/Type check
 
 ### Step 6: Rename Support
 


### PR DESCRIPTION
## Summary

- Extract `syncNewFilesWithRolePrompt` as shared helper for interactive role assignment
- `attach open` now does dry-run → prompt for unknown roles → confirm → apply (instead of silently registering all files)
- Both `attach open` and `attach sync` TTY flows use the same role assignment logic via `promptForUnknownRoles`

## Test plan

- [x] Unit tests for `syncNewFilesWithRolePrompt` (5 new tests covering prompt, skip, decline, empty, "other" kept)
- [x] All existing tests pass (2628 tests, 136 files)
- [x] Lint passes
- [x] Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)