### PR TITLE
feat: add fulltext retrieval configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Fulltext Retrieval Configuration**: Config and environment variable support for OA fulltext retrieval sources
+  - New config section: `[fulltext]` with `prefer_sources` and `[fulltext.sources]` for `unpaywall_email` / `core_api_key`
+  - Default source priority: `["pmc", "arxiv", "unpaywall", "core"]`
+  - Environment variable overrides: `UNPAYWALL_EMAIL`, `CORE_API_KEY`
+  - Config command integration: `ref config list-keys/get/set` works with fulltext keys
+
 - **Root Command Default TUI Search**: `ref` (no subcommand) now launches interactive TUI search
   - TTY: Launches TUI search (same as `ref search -t`)
   - Non-TTY (pipe, script): Shows help (previous behavior preserved)

--- a/spec/tasks/20260208-01-fulltext-retrieval-config.md
+++ b/spec/tasks/20260208-01-fulltext-retrieval-config.md
@@ -30,19 +30,19 @@ Add `fulltextConfigSchema` to `configSchema` with:
 - `sources.unpaywallEmail`: `z.string().optional()`
 - `sources.coreApiKey`: `z.string().optional()`
 
-- [ ] Write test: `src/config/schema.test.ts` (add cases for fulltext config validation)
-- [ ] Implement: Add schema to `src/config/schema.ts`
-- [ ] Verify Green: `npm run test:unit -- schema.test.ts`
-- [ ] Lint/Type check: `npm run lint && npm run typecheck`
+- [x] Write test: `src/config/schema.test.ts` (add cases for fulltext config validation)
+- [x] Implement: Add schema to `src/config/schema.ts`
+- [x] Verify Green: `npm run test:unit -- schema.test.ts`
+- [x] Lint/Type check: `npm run lint && npm run typecheck`
 
 ### Step 2: Config Loader - Add `fillFulltextDefaults()`
 
 Add loader logic following `fillPubmedDefaults()` pattern. Environment variables take priority over config file values.
 
-- [ ] Write test: `src/config/loader.test.ts` (add cases for fulltext config loading, env var priority)
-- [ ] Implement: Add `fillFulltextDefaults()` to `src/config/loader.ts`
-- [ ] Verify Green: `npm run test:unit -- loader.test.ts`
-- [ ] Lint/Type check: `npm run lint && npm run typecheck`
+- [x] Write test: `src/config/loader.test.ts` (add cases for fulltext config loading, env var priority)
+- [x] Implement: Add `fillFulltextDefaults()` to `src/config/loader.ts`
+- [x] Verify Green: `npm run test:unit -- loader.test.ts`
+- [x] Lint/Type check: `npm run lint && npm run typecheck`
 
 ### Step 3: Environment Variable Overrides
 
@@ -50,25 +50,25 @@ Add to `ENV_OVERRIDE_MAP`:
 - `UNPAYWALL_EMAIL` -> `fulltext.sources.unpaywall_email`
 - `CORE_API_KEY` -> `fulltext.sources.core_api_key`
 
-- [ ] Write test: `src/config/env-override.test.ts` (add cases for new env vars)
-- [ ] Implement: Update `src/config/env-override.ts`
-- [ ] Verify Green: `npm run test:unit -- env-override.test.ts`
-- [ ] Lint/Type check: `npm run lint && npm run typecheck`
+- [x] Write test: `src/config/env-override.test.ts` (add cases for new env vars)
+- [x] Implement: Update `src/config/env-override.ts`
+- [x] Verify Green: `npm run test:unit -- env-override.test.ts`
+- [x] Lint/Type check: `npm run lint && npm run typecheck`
 
 ### Step 4: Config Command Integration
 
 Ensure `ref config show/get/set` works with the new fulltext keys. Add to config-command's key list if needed.
 
-- [ ] Verify: `ref config list-keys` includes fulltext keys
-- [ ] Verify: `ref config get fulltext.sources.unpaywall_email` works
-- [ ] Verify: `ref config set fulltext.sources.unpaywall_email "user@example.com"` works
-- [ ] Lint/Type check: `npm run lint && npm run typecheck`
+- [x] Verify: `ref config list-keys` includes fulltext keys
+- [x] Verify: `ref config get fulltext.sources.unpaywall_email` works
+- [x] Verify: `ref config set fulltext.sources.unpaywall_email "user@example.com"` works
+- [x] Lint/Type check: `npm run lint && npm run typecheck`
 
 ## Completion Checklist
 
-- [ ] All tests pass (`npm run test`)
-- [ ] Lint passes (`npm run lint`)
-- [ ] Type check passes (`npm run typecheck`)
-- [ ] Build succeeds (`npm run build`)
-- [ ] CHANGELOG.md updated
+- [x] All tests pass (`npm run test`)
+- [x] Lint passes (`npm run lint`)
+- [x] Type check passes (`npm run typecheck`)
+- [x] Build succeeds (`npm run build`)
+- [x] CHANGELOG.md updated
 - [ ] Move this file to `spec/tasks/completed/`

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -86,6 +86,13 @@ export const defaultConfig: Config = {
     email: undefined,
     apiKey: undefined,
   },
+  fulltext: {
+    preferSources: ["pmc", "arxiv", "unpaywall", "core"],
+    sources: {
+      unpaywallEmail: undefined,
+      coreApiKey: undefined,
+    },
+  },
   attachments: {
     directory: getDefaultAttachmentsDirectory(),
   },

--- a/src/config/env-override.test.ts
+++ b/src/config/env-override.test.ts
@@ -55,6 +55,16 @@ describe("env-override", () => {
       expect(getEnvOverride("mcp.default_limit")).toBe("50");
     });
 
+    it("returns value when UNPAYWALL_EMAIL is set", () => {
+      process.env.UNPAYWALL_EMAIL = "test@example.com";
+      expect(getEnvOverride("fulltext.sources.unpaywall_email")).toBe("test@example.com");
+    });
+
+    it("returns value when CORE_API_KEY is set", () => {
+      process.env.CORE_API_KEY = "my-core-key";
+      expect(getEnvOverride("fulltext.sources.core_api_key")).toBe("my-core-key");
+    });
+
     it("returns null when no override is set", () => {
       expect(getEnvOverride("library")).toBeNull();
       expect(getEnvOverride("pubmed.email")).toBeNull();

--- a/src/config/env-override.ts
+++ b/src/config/env-override.ts
@@ -13,6 +13,8 @@ export const ENV_OVERRIDE_MAP: Record<string, string> = {
   REFERENCE_MANAGER_CLIPBOARD_AUTO_COPY: "cli.tui.clipboard_auto_copy",
   PUBMED_EMAIL: "pubmed.email",
   PUBMED_API_KEY: "pubmed.api_key",
+  UNPAYWALL_EMAIL: "fulltext.sources.unpaywall_email",
+  CORE_API_KEY: "fulltext.sources.core_api_key",
 };
 
 /**

--- a/src/config/key-parser.ts
+++ b/src/config/key-parser.ts
@@ -80,6 +80,25 @@ const CONFIG_KEY_REGISTRY: ConfigKeyInfo[] = [
   { key: "pubmed.email", type: "string", description: "Email for PubMed API", optional: true },
   { key: "pubmed.api_key", type: "string", description: "API key for PubMed", optional: true },
 
+  // fulltext section
+  {
+    key: "fulltext.prefer_sources",
+    type: "string[]",
+    description: "Fulltext source priority order",
+  },
+  {
+    key: "fulltext.sources.unpaywall_email",
+    type: "string",
+    description: "Email for Unpaywall API",
+    optional: true,
+  },
+  {
+    key: "fulltext.sources.core_api_key",
+    type: "string",
+    description: "API key for CORE",
+    optional: true,
+  },
+
   // attachments section
   { key: "attachments.directory", type: "string", description: "Attachments storage directory" },
 


### PR DESCRIPTION
## Summary
- Add `[fulltext]` config section with `prefer_sources` array and `[fulltext.sources]` sub-object (`unpaywall_email`, `core_api_key`)
- Support env var overrides: `UNPAYWALL_EMAIL`, `CORE_API_KEY` (priority over config file)
- Integrate with `ref config list-keys/get/set` commands

## Changes
- `src/config/schema.ts`: `fulltextConfigSchema`, `fulltextSourceSchema`, partial config, normalizer, types
- `src/config/defaults.ts`: Default fulltext config values
- `src/config/loader.ts`: `fillFulltextDefaults()`, `mergeFulltextConfig()`, refactored `mergeConfigs`
- `src/config/env-override.ts`: `UNPAYWALL_EMAIL` / `CORE_API_KEY` env mappings
- `src/config/key-parser.ts`: Registry entries for fulltext config keys

## Test plan
- [x] Schema validation for fulltext config (valid sources, invalid source rejection)
- [x] Loader tests: TOML loading, camelCase/snake_case support, env var priority, partial merge
- [x] Env override tests: `UNPAYWALL_EMAIL`, `CORE_API_KEY` getEnvOverride
- [x] All 2660 existing tests still pass
- [x] Lint, typecheck, build all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)