### PR TITLE
feat(upgrade): self-upgrade Stage 2 — ref upgrade subcommand (#95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Self-Upgrade**: `ref upgrade` subcommand and update-check notifier (#95)
+  - One-line notice on TTY invocations when a newer GitHub release exists
+    (suppressed by `REFERENCE_MANAGER_NO_UPDATE_CHECK=1`, `--no-update-check`,
+    or non-TTY output)
+  - `ref upgrade` detects the install method via `realpathSync(process.argv[1])`
+    and dispatches to the matching strategy:
+    - Single binary (`~/.local/bin/ref` etc.): downloads the platform asset
+      from GitHub Releases, verifies with `--version`, then atomically
+      replaces (Unix) or rotates to `.old` (Windows)
+    - npm-global (`npm i -g …`): prints the recommended `npm i -g` command
+      (or runs it with `--yes`)
+    - Dev / npx: prints guidance and exits 2
+  - Options: `--check`, `--version <tag>`, `--yes`, `--install-dir <path>`
 - **URL Import (Phase 2)**: Enhanced metadata extraction for URL imports
   - JSON-LD (Schema.org) parsing with `@graph` support and nested objects
   - Automatic CSL type inference from JSON-LD `@type` (Legislation, Report, Article, etc.)

--- a/README.md
+++ b/README.md
@@ -93,6 +93,29 @@ irm https://raw.githubusercontent.com/ncukondo/reference-manager/main/install.ps
 
 You can also download binaries directly from [GitHub Releases](https://github.com/ncukondo/reference-manager/releases/latest).
 
+### Upgrading
+
+```bash
+ref upgrade          # Upgrade to the latest release via the detected install method
+ref upgrade --check  # Report current vs. latest without applying the upgrade
+```
+
+`ref upgrade` detects whether you installed via `install.sh` (single binary),
+`npm i -g`, `npm link`, or `npx`, then applies the right strategy:
+
+- **Single binary**: downloads the platform asset from GitHub Releases,
+  verifies it, and atomically replaces the running binary.
+- **npm global**: prints the `npm i -g @ncukondo/reference-manager@latest`
+  command (or runs it with `--yes`).
+- **Dev / npx**: prints guidance and exits.
+
+Pin a specific release with `--version v0.33.4`. Override the target
+directory for the single-binary strategy with `--install-dir <path>`.
+
+Running any command on a TTY also prints a one-line notice when a newer
+release is available. Set `REFERENCE_MANAGER_NO_UPDATE_CHECK=1` or pass
+`--no-update-check` to silence it.
+
 ### From npm
 
 Requires Node.js 22 or later:

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -59,3 +59,6 @@ export type { ExportCommandOptions, ExportCommandResult } from "./export.js";
 
 export { executeEditCommand, formatEditOutput } from "./edit.js";
 export type { EditCommandOptions, EditCommandResult } from "./edit.js";
+
+export { formatUpgradeResult, registerUpgradeCommand, runUpgrade } from "./upgrade.js";
+export type { RunUpgradeDeps, RunUpgradeResult, UpgradeCommandOptions } from "./upgrade.js";

--- a/src/cli/commands/upgrade.test.ts
+++ b/src/cli/commands/upgrade.test.ts
@@ -1,0 +1,241 @@
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import type { UpgradeResult } from "../../upgrade/apply-binary.js";
+import {
+  type RunUpgradeDeps,
+  type UpgradeCommandOptions,
+  formatUpgradeResult,
+  runUpgrade,
+} from "./upgrade.js";
+
+function captureStream(): { stream: NodeJS.WritableStream; output: () => string } {
+  const stream = new PassThrough();
+  let buf = "";
+  stream.on("data", (chunk) => {
+    buf += String(chunk);
+  });
+  return { stream, output: () => buf };
+}
+
+function okResult(overrides: Partial<UpgradeResult> = {}): UpgradeResult {
+  return {
+    status: "success",
+    fromVersion: "0.33.4",
+    toVersion: "0.34.0",
+    ...overrides,
+  };
+}
+
+function defaultDeps(overrides: Partial<RunUpgradeDeps> = {}): RunUpgradeDeps {
+  const { stream: stdout } = captureStream();
+  const { stream: stderr } = captureStream();
+  return {
+    installMethod: "binary",
+    argv1: "/home/user/.local/bin/ref",
+    currentVersion: "0.33.4",
+    upgradeBinaryFn: vi.fn(async () => okResult()),
+    upgradeNpmFn: vi.fn(async () => okResult()),
+    stdout,
+    stderr,
+    ...overrides,
+  };
+}
+
+describe("runUpgrade", () => {
+  it("dispatches to the binary strategy when installMethod='binary'", async () => {
+    const upgradeBinaryFn = vi.fn(async () => okResult());
+    const upgradeNpmFn = vi.fn();
+    const result = await runUpgrade(
+      {} as UpgradeCommandOptions,
+      defaultDeps({
+        installMethod: "binary",
+        upgradeBinaryFn,
+        upgradeNpmFn: upgradeNpmFn as unknown as RunUpgradeDeps["upgradeNpmFn"],
+      })
+    );
+
+    expect(upgradeBinaryFn).toHaveBeenCalledTimes(1);
+    expect(upgradeNpmFn).not.toHaveBeenCalled();
+    expect(result.exitCode).toBe(0);
+    expect(result.method).toBe("binary");
+  });
+
+  it("dispatches to the npm strategy when installMethod='npm-global'", async () => {
+    const upgradeBinaryFn = vi.fn();
+    const upgradeNpmFn = vi.fn(async () => okResult({ status: "guidance" }));
+    const result = await runUpgrade(
+      {} as UpgradeCommandOptions,
+      defaultDeps({
+        installMethod: "npm-global",
+        upgradeBinaryFn: upgradeBinaryFn as unknown as RunUpgradeDeps["upgradeBinaryFn"],
+        upgradeNpmFn,
+      })
+    );
+
+    expect(upgradeBinaryFn).not.toHaveBeenCalled();
+    expect(upgradeNpmFn).toHaveBeenCalledTimes(1);
+    expect(result.exitCode).toBe(0);
+    expect(result.method).toBe("npm-global");
+  });
+
+  it("prints guidance and exits 2 for dev install", async () => {
+    const { stream: stderr, output } = captureStream();
+    const upgradeBinaryFn = vi.fn();
+    const upgradeNpmFn = vi.fn();
+    const result = await runUpgrade(
+      {} as UpgradeCommandOptions,
+      defaultDeps({
+        installMethod: "dev",
+        stderr,
+        upgradeBinaryFn: upgradeBinaryFn as unknown as RunUpgradeDeps["upgradeBinaryFn"],
+        upgradeNpmFn: upgradeNpmFn as unknown as RunUpgradeDeps["upgradeNpmFn"],
+      })
+    );
+
+    expect(upgradeBinaryFn).not.toHaveBeenCalled();
+    expect(upgradeNpmFn).not.toHaveBeenCalled();
+    expect(result.exitCode).toBe(2);
+    expect(output()).toMatch(/dev/i);
+  });
+
+  it("prints guidance and exits 2 for npx install", async () => {
+    const { stream: stderr, output } = captureStream();
+    const result = await runUpgrade(
+      {} as UpgradeCommandOptions,
+      defaultDeps({ installMethod: "npx", stderr })
+    );
+
+    expect(result.exitCode).toBe(2);
+    expect(output()).toMatch(/npx/i);
+  });
+
+  it("passes --check through to the binary strategy without mutating anything", async () => {
+    const upgradeBinaryFn = vi.fn(async () =>
+      okResult({
+        status: "guidance",
+        url: "https://github.com/ncukondo/reference-manager/releases/download/v0.34.0/ref-linux-x64",
+      })
+    );
+    const result = await runUpgrade(
+      { check: true } as UpgradeCommandOptions,
+      defaultDeps({ installMethod: "binary", upgradeBinaryFn })
+    );
+
+    expect(upgradeBinaryFn).toHaveBeenCalledTimes(1);
+    const [firstCallArgs] = upgradeBinaryFn.mock.calls;
+    expect(firstCallArgs?.[0]).toMatchObject({ check: true });
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("passes --version and --yes through to the npm strategy", async () => {
+    const upgradeNpmFn = vi.fn(async () => okResult());
+    await runUpgrade(
+      { version: "v0.35.0", yes: true } as UpgradeCommandOptions,
+      defaultDeps({ installMethod: "npm-global", upgradeNpmFn })
+    );
+
+    const [firstCall] = upgradeNpmFn.mock.calls;
+    expect(firstCall?.[0]).toMatchObject({ version: "v0.35.0", yes: true });
+  });
+
+  it("resolves destPath for the binary strategy from argv1 (realpath)", async () => {
+    const upgradeBinaryFn = vi.fn(async () => okResult());
+    await runUpgrade(
+      {} as UpgradeCommandOptions,
+      defaultDeps({
+        installMethod: "binary",
+        argv1: "/home/user/.local/bin/ref",
+        upgradeBinaryFn,
+      })
+    );
+
+    const [firstCall] = upgradeBinaryFn.mock.calls;
+    // destPath should be the resolved argv1 by default.
+    expect(firstCall?.[0].destPath).toContain("ref");
+  });
+
+  it("honors --install-dir override for the binary strategy", async () => {
+    const upgradeBinaryFn = vi.fn(async () => okResult());
+    await runUpgrade(
+      { installDir: "/opt/custom" } as UpgradeCommandOptions,
+      defaultDeps({ installMethod: "binary", upgradeBinaryFn })
+    );
+
+    const [firstCall] = upgradeBinaryFn.mock.calls;
+    expect(firstCall?.[0].destPath).toBe("/opt/custom/ref");
+  });
+
+  it("exits 1 when the strategy returns status='error'", async () => {
+    const upgradeBinaryFn = vi.fn(async () => ({
+      status: "error" as const,
+      fromVersion: "0.33.4",
+      error: "boom",
+    }));
+    const result = await runUpgrade(
+      {} as UpgradeCommandOptions,
+      defaultDeps({ installMethod: "binary", upgradeBinaryFn })
+    );
+
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("exits 0 when the strategy returns already-up-to-date", async () => {
+    const upgradeBinaryFn = vi.fn(async () => ({
+      status: "already-up-to-date" as const,
+      fromVersion: "0.34.0",
+      toVersion: "0.34.0",
+    }));
+    const result = await runUpgrade(
+      {} as UpgradeCommandOptions,
+      defaultDeps({
+        installMethod: "binary",
+        currentVersion: "0.34.0",
+        upgradeBinaryFn,
+      })
+    );
+
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("formatUpgradeResult", () => {
+  it("formats a success result", () => {
+    const text = formatUpgradeResult({
+      status: "success",
+      fromVersion: "0.33.4",
+      toVersion: "0.34.0",
+    });
+    expect(text).toMatch(/0\.33\.4/);
+    expect(text).toMatch(/0\.34\.0/);
+    expect(text).toMatch(/upgrade|upgraded/i);
+  });
+
+  it("formats an already-up-to-date result", () => {
+    const text = formatUpgradeResult({
+      status: "already-up-to-date",
+      fromVersion: "0.34.0",
+      toVersion: "0.34.0",
+    });
+    expect(text).toMatch(/up.to.date/i);
+  });
+
+  it("formats a guidance result with the command", () => {
+    const text = formatUpgradeResult({
+      status: "guidance",
+      fromVersion: "0.33.4",
+      toVersion: "0.34.0",
+      message: "npm i -g @ncukondo/reference-manager@latest",
+    });
+    expect(text).toContain("npm i -g @ncukondo/reference-manager@latest");
+  });
+
+  it("formats an error result", () => {
+    const text = formatUpgradeResult({
+      status: "error",
+      fromVersion: "0.33.4",
+      error: "network down",
+    });
+    expect(text).toMatch(/error/i);
+    expect(text).toContain("network down");
+  });
+});

--- a/src/cli/commands/upgrade.test.ts
+++ b/src/cli/commands/upgrade.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import type { UpgradeResult } from "../../upgrade/apply-binary.js";
@@ -110,21 +111,25 @@ describe("runUpgrade", () => {
   });
 
   it("passes --check through to the binary strategy without mutating anything", async () => {
+    const assetUrl =
+      "https://github.com/ncukondo/reference-manager/releases/download/v0.34.0/ref-linux-x64";
     const upgradeBinaryFn = vi.fn(async () =>
       okResult({
         status: "guidance",
-        url: "https://github.com/ncukondo/reference-manager/releases/download/v0.34.0/ref-linux-x64",
+        url: assetUrl,
       })
     );
+    const { stream: stdout, output } = captureStream();
     const result = await runUpgrade(
       { check: true } as UpgradeCommandOptions,
-      defaultDeps({ installMethod: "binary", upgradeBinaryFn })
+      defaultDeps({ installMethod: "binary", upgradeBinaryFn, stdout })
     );
 
     expect(upgradeBinaryFn).toHaveBeenCalledTimes(1);
     const [firstCallArgs] = upgradeBinaryFn.mock.calls;
     expect(firstCallArgs?.[0]).toMatchObject({ check: true });
     expect(result.exitCode).toBe(0);
+    expect(output()).toContain(assetUrl);
   });
 
   it("passes --version and --yes through to the npm strategy", async () => {
@@ -162,7 +167,8 @@ describe("runUpgrade", () => {
     );
 
     const [firstCall] = upgradeBinaryFn.mock.calls;
-    expect(firstCall?.[0].destPath).toBe("/opt/custom/ref");
+    const expected = join("/opt/custom", process.platform === "win32" ? "ref.exe" : "ref");
+    expect(firstCall?.[0].destPath).toBe(expected);
   });
 
   it("exits 1 when the strategy returns status='error'", async () => {
@@ -227,6 +233,20 @@ describe("formatUpgradeResult", () => {
       message: "npm i -g @ncukondo/reference-manager@latest",
     });
     expect(text).toContain("npm i -g @ncukondo/reference-manager@latest");
+  });
+
+  it("appends the asset url for a binary guidance result (no message)", () => {
+    const url =
+      "https://github.com/ncukondo/reference-manager/releases/download/v0.34.0/ref-linux-x64";
+    const text = formatUpgradeResult({
+      status: "guidance",
+      fromVersion: "0.33.4",
+      toVersion: "0.34.0",
+      url,
+    });
+    expect(text).toContain("0.33.4");
+    expect(text).toContain("0.34.0");
+    expect(text).toContain(url);
   });
 
   it("formats an error result", () => {

--- a/src/cli/commands/upgrade.ts
+++ b/src/cli/commands/upgrade.ts
@@ -78,8 +78,10 @@ export function formatUpgradeResult(result: UpgradeResult): string {
       return `Upgraded ref ${from} -> ${to}`;
     case "already-up-to-date":
       return `Already up to date (${to})`;
-    case "guidance":
-      return result.message ? `${result.message}` : `Run the upgrade for ${from} -> ${to}`;
+    case "guidance": {
+      const base = result.message ?? `Run the upgrade for ${from} -> ${to}`;
+      return result.url ? `${base} (${result.url})` : base;
+    }
     case "error":
       return `Error: ${result.error ?? "upgrade failed"}`;
   }

--- a/src/cli/commands/upgrade.ts
+++ b/src/cli/commands/upgrade.ts
@@ -1,0 +1,151 @@
+/**
+ * `ref upgrade` command — applies a new release via the detected install method.
+ *
+ * See: spec/features/self-upgrade.md
+ */
+
+import { realpathSync } from "node:fs";
+import { join } from "node:path";
+import type { Command } from "commander";
+import packageJson from "../../../package.json" with { type: "json" };
+import {
+  type UpgradeBinaryOptions,
+  type UpgradeResult,
+  upgradeBinary,
+} from "../../upgrade/apply-binary.js";
+import { type UpgradeNpmOptions, upgradeNpmGlobal } from "../../upgrade/apply-npm.js";
+import { type InstallMethod, detectInstallMethod } from "../../upgrade/detect.js";
+import { ExitCode, setExitCode } from "../helpers.js";
+
+export interface UpgradeCommandOptions {
+  check?: boolean;
+  version?: string;
+  yes?: boolean;
+  installDir?: string;
+}
+
+export interface RunUpgradeDeps {
+  installMethod?: InstallMethod;
+  argv1?: string;
+  currentVersion?: string;
+  upgradeBinaryFn?: (options: UpgradeBinaryOptions) => Promise<UpgradeResult>;
+  upgradeNpmFn?: (options: UpgradeNpmOptions) => Promise<UpgradeResult>;
+  stdout?: NodeJS.WritableStream;
+  stderr?: NodeJS.WritableStream;
+}
+
+export interface RunUpgradeResult {
+  exitCode: 0 | 1 | 2;
+  method: InstallMethod;
+  result?: UpgradeResult;
+}
+
+function resolveDestPath(argv1: string, installDir: string | undefined): string {
+  if (installDir) {
+    const basename = process.platform === "win32" ? "ref.exe" : "ref";
+    return join(installDir, basename);
+  }
+  try {
+    return realpathSync(argv1);
+  } catch {
+    return argv1;
+  }
+}
+
+function devGuidance(method: "dev" | "npx"): string {
+  if (method === "npx") {
+    return (
+      "Detected an npx invocation (cache-resident copy). `ref upgrade` does nothing here — " +
+      "npx fetches the latest on each run, or pin a version with `npx @ncukondo/reference-manager@<tag>`.\n"
+    );
+  }
+  return (
+    "Detected a dev install (npm link or in-tree). `ref upgrade` does not modify dev trees. " +
+    "Use `git pull && npm run build` in the source checkout, or reinstall with `install.sh` " +
+    "or `npm i -g @ncukondo/reference-manager`.\n"
+  );
+}
+
+function exitCodeFor(status: UpgradeResult["status"]): 0 | 1 {
+  return status === "error" ? 1 : 0;
+}
+
+export function formatUpgradeResult(result: UpgradeResult): string {
+  const from = result.fromVersion ?? "?";
+  const to = result.toVersion ?? "?";
+  switch (result.status) {
+    case "success":
+      return `Upgraded ref ${from} -> ${to}`;
+    case "already-up-to-date":
+      return `Already up to date (${to})`;
+    case "guidance":
+      return result.message ? `${result.message}` : `Run the upgrade for ${from} -> ${to}`;
+    case "error":
+      return `Error: ${result.error ?? "upgrade failed"}`;
+  }
+}
+
+function buildBinaryOptions(
+  options: UpgradeCommandOptions,
+  argv1: string,
+  currentVersion: string
+): UpgradeBinaryOptions {
+  const destPath = resolveDestPath(argv1, options.installDir);
+  const out: UpgradeBinaryOptions = { destPath, currentVersion };
+  if (options.check !== undefined) out.check = options.check;
+  if (options.version !== undefined) out.version = options.version;
+  return out;
+}
+
+function buildNpmOptions(
+  options: UpgradeCommandOptions,
+  currentVersion: string
+): UpgradeNpmOptions {
+  const out: UpgradeNpmOptions = { currentVersion };
+  if (options.check !== undefined) out.check = options.check;
+  if (options.yes !== undefined) out.yes = options.yes;
+  if (options.version !== undefined) out.version = options.version;
+  return out;
+}
+
+export async function runUpgrade(
+  options: UpgradeCommandOptions,
+  deps: RunUpgradeDeps = {}
+): Promise<RunUpgradeResult> {
+  const installMethod = deps.installMethod ?? detectInstallMethod(deps.argv1 ?? process.argv[1]);
+  const argv1 = deps.argv1 ?? process.argv[1] ?? "";
+  const currentVersion = deps.currentVersion ?? packageJson.version;
+  const upgradeBinaryFn = deps.upgradeBinaryFn ?? upgradeBinary;
+  const upgradeNpmFn = deps.upgradeNpmFn ?? upgradeNpmGlobal;
+  const stdout = deps.stdout ?? process.stdout;
+  const stderr = deps.stderr ?? process.stderr;
+
+  if (installMethod === "dev" || installMethod === "npx") {
+    stderr.write(devGuidance(installMethod));
+    return { exitCode: 2, method: installMethod };
+  }
+
+  const result =
+    installMethod === "binary"
+      ? await upgradeBinaryFn(buildBinaryOptions(options, argv1, currentVersion))
+      : await upgradeNpmFn(buildNpmOptions(options, currentVersion));
+
+  const target = result.status === "error" ? stderr : stdout;
+  target.write(`${formatUpgradeResult(result)}\n`);
+
+  return { exitCode: exitCodeFor(result.status), method: installMethod, result };
+}
+
+export function registerUpgradeCommand(program: Command): void {
+  program
+    .command("upgrade")
+    .description("Upgrade `ref` to the latest release (or a pinned version)")
+    .option("--check", "Report current vs. latest without applying any upgrade")
+    .option("--version <tag>", "Pin to a specific release tag (e.g. v0.33.4)")
+    .option("-y, --yes", "Skip confirmation prompts (applies to npm-global strategy)")
+    .option("--install-dir <path>", "Override install directory for the single-binary strategy")
+    .action(async (options: UpgradeCommandOptions) => {
+      const result = await runUpgrade(options);
+      setExitCode(result.exitCode === 0 ? ExitCode.SUCCESS : result.exitCode);
+    });
+}

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import packageJson from "../../package.json" with { type: "json" };
-import { createProgram, extractCommandName, hasNoUpdateCheckFlag } from "./index.js";
+import {
+  createProgram,
+  extractCommandName,
+  hasNoUpdateCheckFlag,
+  rewriteUpgradeVersionFlag,
+} from "./index.js";
 
 describe("CLI Entry", () => {
   describe("createProgram", () => {
@@ -225,6 +230,57 @@ describe("CLI Entry", () => {
         expect(hasNoUpdateCheckFlag(["node", "cli.js", "--no-update-check=value", "list"])).toBe(
           false
         );
+      });
+    });
+
+    describe("rewriteUpgradeVersionFlag", () => {
+      it("converts 'upgrade --version <tag>' to 'upgrade --version=<tag>'", () => {
+        expect(
+          rewriteUpgradeVersionFlag(["node", "cli.js", "upgrade", "--version", "v0.34.0"])
+        ).toEqual(["node", "cli.js", "upgrade", "--version=v0.34.0"]);
+      });
+
+      it("preserves other arguments around the rewritten flag", () => {
+        expect(
+          rewriteUpgradeVersionFlag([
+            "node",
+            "cli.js",
+            "upgrade",
+            "--check",
+            "--version",
+            "v0.0.0",
+            "--yes",
+          ])
+        ).toEqual(["node", "cli.js", "upgrade", "--check", "--version=v0.0.0", "--yes"]);
+      });
+
+      it("does not rewrite when the subcommand is not 'upgrade'", () => {
+        // `--version` on a non-upgrade command should remain untouched so the
+        // root program's version handler still fires.
+        expect(rewriteUpgradeVersionFlag(["node", "cli.js", "list", "--version"])).toEqual([
+          "node",
+          "cli.js",
+          "list",
+          "--version",
+        ]);
+        expect(rewriteUpgradeVersionFlag(["node", "cli.js", "--version"])).toEqual([
+          "node",
+          "cli.js",
+          "--version",
+        ]);
+      });
+
+      it("does not touch the already-merged '--version=<tag>' form", () => {
+        expect(
+          rewriteUpgradeVersionFlag(["node", "cli.js", "upgrade", "--version=v0.34.0"])
+        ).toEqual(["node", "cli.js", "upgrade", "--version=v0.34.0"]);
+      });
+
+      it("does not eat the next token when it starts with '-'", () => {
+        // `--version --check` — `--check` is another flag, not a value.
+        expect(
+          rewriteUpgradeVersionFlag(["node", "cli.js", "upgrade", "--version", "--check"])
+        ).toEqual(["node", "cli.js", "upgrade", "--version", "--check"]);
       });
     });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -61,6 +61,7 @@ import {
 import { serverStart, serverStatus, serverStop } from "./commands/server.js";
 import { handleShowAction } from "./commands/show.js";
 import { collectSetOption, handleUpdateAction } from "./commands/update.js";
+import { registerUpgradeCommand } from "./commands/upgrade.js";
 import { handleUrlAction } from "./commands/url.js";
 import { handleCompletion, registerCompletionCommand } from "./completion.js";
 import { type ExecutionContext, createExecutionContext } from "./execution-context.js";
@@ -133,6 +134,7 @@ export function createProgram(): Command {
   registerUrlCommand(program);
   registerInstallCommand(program);
   registerConfigCommand(program);
+  registerUpgradeCommand(program);
   registerCompletionCommand(program);
 
   return program;
@@ -1078,6 +1080,34 @@ export function hasNoUpdateCheckFlag(argv: string[]): boolean {
 }
 
 /**
+ * Rewrite `ref upgrade --version <tag>` to `ref upgrade --version=<tag>`.
+ *
+ * The program has `.version(packageJson.version)` which registers a no-arg
+ * `--version` flag at the root. Commander's parser consumes the root
+ * `--version` before subcommand options, so the space-separated form is
+ * caught by the root (prints + exits) instead of reaching `upgrade`'s
+ * `--version <tag>`. The `=` form binds the value to the subcommand's
+ * option and sidesteps the root flag.
+ */
+export function rewriteUpgradeVersionFlag(argv: string[]): string[] {
+  if (extractCommandName(argv) !== "upgrade") return argv;
+  const out: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    if (token === "--version" && i + 1 < argv.length) {
+      const next = argv[i + 1];
+      if (next !== undefined && !next.startsWith("-")) {
+        out.push(`--version=${next}`);
+        i++;
+        continue;
+      }
+    }
+    if (token !== undefined) out.push(token);
+  }
+  return out;
+}
+
+/**
  * Main CLI entry point
  */
 export async function main(argv: string[]): Promise<void> {
@@ -1098,11 +1128,13 @@ export async function main(argv: string[]): Promise<void> {
     setExitCode(ExitCode.SUCCESS);
   });
 
+  const normalizedArgv = rewriteUpgradeVersionFlag(argv);
+
   // Kick off async update check before command runs. The notifier registers
   // its own exit listener to print the notice after the user's command.
-  maybeStartUpdateCheck(extractCommandName(argv, program), {
-    noUpdateCheck: hasNoUpdateCheckFlag(argv),
+  maybeStartUpdateCheck(extractCommandName(normalizedArgv, program), {
+    noUpdateCheck: hasNoUpdateCheckFlag(normalizedArgv),
   });
 
-  await program.parseAsync(argv);
+  await program.parseAsync(normalizedArgv);
 }

--- a/src/upgrade/apply-binary.test.ts
+++ b/src/upgrade/apply-binary.test.ts
@@ -1,0 +1,242 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type UpgradeBinaryOptions, computeAssetName, upgradeBinary } from "./apply-binary.js";
+
+function makeFetchBinary(bytes: Uint8Array, status = 200): typeof globalThis.fetch {
+  return vi.fn(async () => {
+    return new Response(bytes, {
+      status,
+      headers: { "content-type": "application/octet-stream" },
+    });
+  }) as unknown as typeof globalThis.fetch;
+}
+
+function makeFetchStatus(status: number): typeof globalThis.fetch {
+  return vi.fn(
+    async () =>
+      new Response("not found", {
+        status,
+        headers: { "content-type": "text/plain" },
+      })
+  ) as unknown as typeof globalThis.fetch;
+}
+
+describe("computeAssetName", () => {
+  it.each([
+    ["linux", "x64", "ref-linux-x64"],
+    ["linux", "arm64", "ref-linux-arm64"],
+    ["darwin", "x64", "ref-darwin-x64"],
+    ["darwin", "arm64", "ref-darwin-arm64"],
+    ["win32", "x64", "ref-windows-x64.exe"],
+  ])("platform=%s arch=%s -> %s", (platform, arch, expected) => {
+    expect(computeAssetName(platform as NodeJS.Platform, arch)).toBe(expected);
+  });
+
+  it("throws for unsupported platform", () => {
+    expect(() => computeAssetName("freebsd" as NodeJS.Platform, "x64")).toThrow(/unsupported/i);
+  });
+
+  it("throws for unsupported arch", () => {
+    expect(() => computeAssetName("linux", "ia32")).toThrow(/unsupported/i);
+  });
+});
+
+describe("upgradeBinary", () => {
+  let testDir: string;
+  let destPath: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `upgrade-binary-test-${randomUUID()}`);
+    mkdirSync(testDir, { recursive: true });
+    destPath = join(testDir, "ref");
+    // Seed a fake existing binary so dest exists.
+    writeFileSync(destPath, "old binary\n", { mode: 0o755 });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
+  });
+
+  function baseOptions(overrides: Partial<UpgradeBinaryOptions> = {}): UpgradeBinaryOptions {
+    return {
+      destPath,
+      currentVersion: "0.33.4",
+      platform: "linux",
+      arch: "x64",
+      pid: 12345,
+      fetch: makeFetchBinary(new TextEncoder().encode("new binary contents")),
+      verifyBinary: vi.fn(async () => "ref 0.34.0"),
+      getLatest: vi.fn(async () => ({
+        checkedAt: "2026-04-20T12:00:00Z",
+        latest: "0.34.0",
+        url: "https://github.com/ncukondo/reference-manager/releases/tag/v0.34.0",
+      })),
+      ...overrides,
+    };
+  }
+
+  it("downloads to {dest}.tmp.{pid}, verifies, then moves into place", async () => {
+    const verifyCalls: string[] = [];
+    const options = baseOptions({
+      verifyBinary: vi.fn(async (path: string) => {
+        verifyCalls.push(path);
+        return "ref 0.34.0";
+      }),
+    });
+
+    const result = await upgradeBinary(options);
+
+    expect(result.status).toBe("success");
+    expect(result.fromVersion).toBe("0.33.4");
+    expect(result.toVersion).toBe("0.34.0");
+    expect(readFileSync(destPath, "utf-8")).toBe("new binary contents");
+    // Temp file should not remain after success.
+    expect(existsSync(`${destPath}.tmp.12345`)).toBe(false);
+    // Verify was called against the .tmp path, not dest.
+    expect(verifyCalls).toEqual([`${destPath}.tmp.12345`]);
+  });
+
+  it("uses `--version <tag>` when provided, bypassing getLatest", async () => {
+    const getLatest = vi.fn();
+    const fetchFn = vi.fn(async (url: URL | string) => {
+      expect(String(url)).toContain("/download/v0.35.0/ref-linux-x64");
+      return new Response(new TextEncoder().encode("pinned binary"), { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const result = await upgradeBinary(
+      baseOptions({
+        version: "v0.35.0",
+        fetch: fetchFn,
+        getLatest,
+        verifyBinary: vi.fn(async () => "ref 0.35.0"),
+      })
+    );
+
+    expect(result.status).toBe("success");
+    expect(result.toVersion).toBe("0.35.0");
+    expect(getLatest).not.toHaveBeenCalled();
+  });
+
+  it("accepts a `--version` tag without leading v", async () => {
+    const fetchFn = vi.fn(async (url: URL | string) => {
+      expect(String(url)).toContain("/download/v0.35.0/");
+      return new Response(new TextEncoder().encode("bin"), { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const result = await upgradeBinary(baseOptions({ version: "0.35.0", fetch: fetchFn }));
+    expect(result.status).toBe("success");
+  });
+
+  it("returns already-up-to-date when latest equals current version", async () => {
+    const fetchFn = vi.fn();
+    const result = await upgradeBinary(
+      baseOptions({
+        currentVersion: "0.34.0",
+        fetch: fetchFn as unknown as typeof globalThis.fetch,
+      })
+    );
+
+    expect(result.status).toBe("already-up-to-date");
+    expect(result.fromVersion).toBe("0.34.0");
+    expect(result.toVersion).toBe("0.34.0");
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("returns guidance with asset URL when check=true", async () => {
+    const fetchFn = vi.fn();
+    const result = await upgradeBinary(
+      baseOptions({
+        check: true,
+        fetch: fetchFn as unknown as typeof globalThis.fetch,
+      })
+    );
+
+    expect(result.status).toBe("guidance");
+    expect(result.toVersion).toBe("0.34.0");
+    expect(result.url).toBe(
+      "https://github.com/ncukondo/reference-manager/releases/download/v0.34.0/ref-linux-x64"
+    );
+    expect(fetchFn).not.toHaveBeenCalled();
+    // Dest untouched.
+    expect(readFileSync(destPath, "utf-8")).toBe("old binary\n");
+  });
+
+  it("surfaces the release URL in the error on download 404", async () => {
+    const result = await upgradeBinary(
+      baseOptions({
+        fetch: makeFetchStatus(404),
+      })
+    );
+
+    expect(result.status).toBe("error");
+    expect(result.error).toMatch(/404/);
+    expect(result.error).toContain(
+      "https://github.com/ncukondo/reference-manager/releases/download/v0.34.0/ref-linux-x64"
+    );
+    // Dest untouched on 404.
+    expect(readFileSync(destPath, "utf-8")).toBe("old binary\n");
+  });
+
+  it("returns error when getLatest resolves to null and no version pinned", async () => {
+    const result = await upgradeBinary(
+      baseOptions({
+        getLatest: vi.fn(async () => null),
+      })
+    );
+    expect(result.status).toBe("error");
+    expect(result.error).toMatch(/latest/i);
+  });
+
+  it("leaves the .tmp file in place and returns error when verification fails", async () => {
+    const result = await upgradeBinary(
+      baseOptions({
+        verifyBinary: vi.fn(async () => null),
+      })
+    );
+
+    expect(result.status).toBe("error");
+    expect(result.error).toMatch(/verif/i);
+    // Tmp preserved so the user can inspect the broken download.
+    expect(existsSync(`${destPath}.tmp.12345`)).toBe(true);
+    // Dest not replaced.
+    expect(readFileSync(destPath, "utf-8")).toBe("old binary\n");
+  });
+
+  it("on Windows, rotates dest to .old before moving new binary into place", async () => {
+    const winDest = join(testDir, "ref.exe");
+    writeFileSync(winDest, "old windows\n", { mode: 0o755 });
+
+    const result = await upgradeBinary(
+      baseOptions({
+        destPath: winDest,
+        platform: "win32",
+        arch: "x64",
+        fetch: makeFetchBinary(new TextEncoder().encode("new exe")),
+        verifyBinary: vi.fn(async () => "ref 0.34.0"),
+      })
+    );
+
+    expect(result.status).toBe("success");
+    expect(readFileSync(winDest, "utf-8")).toBe("new exe");
+    // Old binary should remain at .old for best-effort cleanup on next run.
+    expect(readFileSync(`${winDest}.old`, "utf-8")).toBe("old windows\n");
+  });
+
+  it("propagates network errors without touching dest", async () => {
+    const result = await upgradeBinary(
+      baseOptions({
+        fetch: vi.fn(async () => {
+          throw new Error("network down");
+        }) as unknown as typeof globalThis.fetch,
+      })
+    );
+
+    expect(result.status).toBe("error");
+    expect(result.error).toMatch(/network down/);
+    expect(readFileSync(destPath, "utf-8")).toBe("old binary\n");
+    expect(existsSync(`${destPath}.tmp.12345`)).toBe(false);
+  });
+});

--- a/src/upgrade/apply-binary.ts
+++ b/src/upgrade/apply-binary.ts
@@ -1,0 +1,301 @@
+/**
+ * Binary upgrade strategy for `ref upgrade` on single-binary installs.
+ *
+ * Downloads the latest release asset for the current platform to
+ * `{dest}.tmp.{pid}`, verifies it by invoking `--version`, then atomically
+ * replaces the running binary.
+ *
+ * See: spec/features/self-upgrade.md §Atomic replace.
+ */
+
+import { execFile } from "node:child_process";
+import { chmodSync, existsSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { promisify } from "node:util";
+import { type ReleaseInfo, getLatestVersion } from "./check.js";
+
+const execFileAsync = promisify(execFile);
+
+const REPO = "ncukondo/reference-manager";
+
+export type UpgradeStatus = "success" | "already-up-to-date" | "guidance" | "error";
+
+export interface UpgradeResult {
+  status: UpgradeStatus;
+  fromVersion?: string;
+  toVersion?: string;
+  url?: string;
+  message?: string;
+  error?: string;
+}
+
+export interface UpgradeBinaryOptions {
+  /** Absolute path to the binary that should be replaced. */
+  destPath: string;
+  /** The version of the currently running `ref`, without leading `v`. */
+  currentVersion: string;
+  /** Explicit release tag (e.g. "v0.34.0" or "0.34.0"). When unset, uses `getLatest`. */
+  version?: string;
+  /** Report mode only: do not mutate anything. */
+  check?: boolean;
+  /** Defaults to `process.platform`. */
+  platform?: NodeJS.Platform;
+  /** Defaults to `process.arch`. */
+  arch?: string;
+  /** Defaults to `process.pid`. */
+  pid?: number;
+  /** Injection points. */
+  fetch?: typeof globalThis.fetch;
+  getLatest?: () => Promise<ReleaseInfo | null>;
+  /**
+   * Runs the downloaded binary's `--version` command and returns the stdout
+   * (or null on failure). Injected so unit tests don't execute real children.
+   */
+  verifyBinary?: (path: string) => Promise<string | null>;
+}
+
+export function computeAssetName(platform: NodeJS.Platform, arch: string): string {
+  const osName = mapPlatform(platform);
+  const archName = mapArch(arch);
+  const suffix = osName === "windows" ? ".exe" : "";
+  return `ref-${osName}-${archName}${suffix}`;
+}
+
+function mapPlatform(platform: NodeJS.Platform): "linux" | "darwin" | "windows" {
+  if (platform === "linux") return "linux";
+  if (platform === "darwin") return "darwin";
+  if (platform === "win32") return "windows";
+  throw new Error(`unsupported platform: ${platform}`);
+}
+
+function mapArch(arch: string): "x64" | "arm64" {
+  if (arch === "x64") return "x64";
+  if (arch === "arm64") return "arm64";
+  throw new Error(`unsupported arch: ${arch}`);
+}
+
+function normalizeTag(tag: string): string {
+  return tag.startsWith("v") ? tag : `v${tag}`;
+}
+
+function stripV(tag: string): string {
+  return tag.startsWith("v") ? tag.slice(1) : tag;
+}
+
+function buildAssetUrl(tag: string, assetName: string): string {
+  return `https://github.com/${REPO}/releases/download/${tag}/${assetName}`;
+}
+
+function errorResult(
+  fromVersion: string,
+  error: string,
+  extras: { toVersion?: string; url?: string } = {}
+): UpgradeResult {
+  return {
+    status: "error",
+    fromVersion,
+    ...(extras.toVersion !== undefined && { toVersion: extras.toVersion }),
+    ...(extras.url !== undefined && { url: extras.url }),
+    error,
+  };
+}
+
+/**
+ * Default verifier: execs `{path} --version` with a short timeout. Returns the
+ * trimmed stdout on success, or null if the binary fails to run.
+ */
+async function defaultVerifyBinary(path: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(path, ["--version"], {
+      timeout: 5000,
+    });
+    const trimmed = stdout.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+interface ResolvedTarget {
+  targetTag: string;
+  targetVersion: string;
+  releaseHtmlUrl?: string;
+}
+
+async function resolveTarget(
+  pinnedVersion: string | undefined,
+  getLatest: () => Promise<ReleaseInfo | null>
+): Promise<ResolvedTarget | { error: string }> {
+  if (pinnedVersion) {
+    const targetTag = normalizeTag(pinnedVersion);
+    return { targetTag, targetVersion: stripV(targetTag) };
+  }
+  const release = await getLatest();
+  if (!release) {
+    return { error: "Could not determine the latest release. Check your network connection." };
+  }
+  const targetTag = normalizeTag(release.latest);
+  return {
+    targetTag,
+    targetVersion: stripV(targetTag),
+    releaseHtmlUrl: release.url,
+  };
+}
+
+async function downloadAsset(
+  url: string,
+  tmpPath: string,
+  fetchFn: typeof globalThis.fetch
+): Promise<{ error?: string }> {
+  let response: Response;
+  try {
+    response = await fetchFn(url);
+  } catch (error) {
+    return {
+      error: `Download failed: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  if (response.status === 404) {
+    return { error: `Download returned 404. Asset not found at: ${url}` };
+  }
+  if (!response.ok) {
+    return { error: `Download failed with HTTP ${response.status}: ${url}` };
+  }
+
+  try {
+    const buffer = Buffer.from(await response.arrayBuffer());
+    writeFileSync(tmpPath, buffer);
+    chmodSync(tmpPath, 0o755);
+  } catch (error) {
+    if (existsSync(tmpPath)) {
+      try {
+        rmSync(tmpPath, { force: true });
+      } catch {
+        // ignore
+      }
+    }
+    return {
+      error: `Failed to write downloaded binary: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+  return {};
+}
+
+function atomicReplace(
+  tmpPath: string,
+  destPath: string,
+  platform: NodeJS.Platform
+): { error?: string } {
+  try {
+    if (platform === "win32") {
+      const oldPath = `${destPath}.old`;
+      if (existsSync(oldPath)) {
+        try {
+          rmSync(oldPath, { force: true });
+        } catch {
+          // Best-effort: ignore if .old cannot be removed.
+        }
+      }
+      if (existsSync(destPath)) {
+        renameSync(destPath, oldPath);
+      }
+      renameSync(tmpPath, destPath);
+    } else {
+      if (existsSync(destPath)) {
+        rmSync(destPath, { force: true });
+      }
+      renameSync(tmpPath, destPath);
+    }
+  } catch (error) {
+    return {
+      error: `Failed to replace ${destPath}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+  return {};
+}
+
+export async function upgradeBinary(options: UpgradeBinaryOptions): Promise<UpgradeResult> {
+  const {
+    destPath,
+    currentVersion,
+    version: pinnedVersion,
+    check = false,
+    platform = process.platform,
+    arch = process.arch,
+    pid = process.pid,
+    fetch: fetchFn = globalThis.fetch,
+    getLatest = getLatestVersion,
+    verifyBinary = defaultVerifyBinary,
+  } = options;
+
+  const resolved = await resolveTarget(pinnedVersion, getLatest);
+  if ("error" in resolved) {
+    return errorResult(currentVersion, resolved.error);
+  }
+  const { targetTag, targetVersion, releaseHtmlUrl } = resolved;
+
+  // Fast path: already up-to-date (skipped in check mode so we still report).
+  if (!pinnedVersion && currentVersion === targetVersion && !check) {
+    return {
+      status: "already-up-to-date",
+      fromVersion: currentVersion,
+      toVersion: targetVersion,
+      ...(releaseHtmlUrl !== undefined && { url: releaseHtmlUrl }),
+    };
+  }
+
+  let assetName: string;
+  try {
+    assetName = computeAssetName(platform, arch);
+  } catch (error) {
+    return errorResult(currentVersion, error instanceof Error ? error.message : String(error), {
+      toVersion: targetVersion,
+    });
+  }
+  const assetUrl = buildAssetUrl(targetTag, assetName);
+
+  if (check) {
+    return {
+      status:
+        currentVersion === targetVersion && !pinnedVersion ? "already-up-to-date" : "guidance",
+      fromVersion: currentVersion,
+      toVersion: targetVersion,
+      url: assetUrl,
+    };
+  }
+
+  const tmpPath = `${destPath}.tmp.${pid}`;
+  const dl = await downloadAsset(assetUrl, tmpPath, fetchFn);
+  if (dl.error) {
+    return errorResult(currentVersion, dl.error, { toVersion: targetVersion, url: assetUrl });
+  }
+
+  const verified = await verifyBinary(tmpPath);
+  if (!verified) {
+    return errorResult(
+      currentVersion,
+      `Verification failed: downloaded binary at ${tmpPath} did not report a version. The file has been left in place for inspection.`,
+      { toVersion: targetVersion, url: assetUrl }
+    );
+  }
+
+  const replaced = atomicReplace(tmpPath, destPath, platform);
+  if (replaced.error) {
+    return errorResult(currentVersion, replaced.error, {
+      toVersion: targetVersion,
+      url: assetUrl,
+    });
+  }
+
+  return {
+    status: "success",
+    fromVersion: currentVersion,
+    toVersion: targetVersion,
+    url: assetUrl,
+    message: verified,
+  };
+}

--- a/src/upgrade/apply-npm.test.ts
+++ b/src/upgrade/apply-npm.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { type UpgradeNpmOptions, upgradeNpmGlobal } from "./apply-npm.js";
+import { type UpgradeNpmOptions, defaultRunCommand, upgradeNpmGlobal } from "./apply-npm.js";
 
 function baseOptions(overrides: Partial<UpgradeNpmOptions> = {}): UpgradeNpmOptions {
   return {
@@ -90,5 +90,26 @@ describe("upgradeNpmGlobal", () => {
     expect(result.message).toContain("@0.35.0");
     expect(result.toVersion).toBe("0.35.0");
     expect(getLatest).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a friendly message when npm is not on PATH (ENOENT)", async () => {
+    const runCommand = vi.fn(async () =>
+      defaultRunCommand("ref-nonexistent-binary-for-test-xyz", ["--version"])
+    );
+    const result = await upgradeNpmGlobal(baseOptions({ yes: true, runCommand }));
+
+    expect(result.status).toBe("error");
+    expect(result.error).toMatch(/not found in PATH/);
+    expect(result.error).not.toMatch(/spawn ENOENT/);
+  });
+});
+
+describe("defaultRunCommand", () => {
+  it("returns a friendly ENOENT message when the command is missing", async () => {
+    const result = await defaultRunCommand("ref-nonexistent-binary-for-test-xyz", ["--version"]);
+
+    expect(result.exitCode).toBe(127);
+    expect(result.stderr).toContain("not found in PATH");
+    expect(result.stderr).not.toContain("spawn ENOENT");
   });
 });

--- a/src/upgrade/apply-npm.test.ts
+++ b/src/upgrade/apply-npm.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { type UpgradeNpmOptions, upgradeNpmGlobal } from "./apply-npm.js";
+
+function baseOptions(overrides: Partial<UpgradeNpmOptions> = {}): UpgradeNpmOptions {
+  return {
+    currentVersion: "0.33.4",
+    getLatest: vi.fn(async () => ({
+      checkedAt: "2026-04-20T12:00:00Z",
+      latest: "0.34.0",
+      url: "https://github.com/ncukondo/reference-manager/releases/tag/v0.34.0",
+    })),
+    runCommand: vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "" })),
+    ...overrides,
+  };
+}
+
+describe("upgradeNpmGlobal", () => {
+  it("returns guidance with the recommended command when check=true", async () => {
+    const runCommand = vi.fn();
+    const result = await upgradeNpmGlobal(baseOptions({ check: true, runCommand }));
+
+    expect(result.status).toBe("guidance");
+    expect(result.message).toContain("npm i -g @ncukondo/reference-manager@latest");
+    expect(result.toVersion).toBe("0.34.0");
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it("returns already-up-to-date when latest equals current version", async () => {
+    const runCommand = vi.fn();
+    const result = await upgradeNpmGlobal(baseOptions({ currentVersion: "0.34.0", runCommand }));
+
+    expect(result.status).toBe("already-up-to-date");
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it("does not run npm without --yes; returns guidance with the command", async () => {
+    const runCommand = vi.fn();
+    const result = await upgradeNpmGlobal(baseOptions({ runCommand }));
+
+    expect(result.status).toBe("guidance");
+    expect(result.message).toContain("npm i -g @ncukondo/reference-manager@latest");
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it("runs `npm i -g @ncukondo/reference-manager@latest` when yes=true", async () => {
+    const runCommand = vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "" }));
+    const result = await upgradeNpmGlobal(baseOptions({ yes: true, runCommand }));
+
+    expect(runCommand).toHaveBeenCalledTimes(1);
+    const [command, args] = runCommand.mock.calls[0] ?? [];
+    expect(command).toBe("npm");
+    expect(args).toEqual(["i", "-g", "@ncukondo/reference-manager@latest"]);
+    expect(result.status).toBe("success");
+    expect(result.toVersion).toBe("0.34.0");
+  });
+
+  it("pins to the explicit tag when --version is provided and yes=true", async () => {
+    const runCommand = vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "" }));
+    await upgradeNpmGlobal(baseOptions({ yes: true, version: "v0.35.0", runCommand }));
+
+    const [, args] = runCommand.mock.calls[0] ?? [];
+    expect(args).toEqual(["i", "-g", "@ncukondo/reference-manager@0.35.0"]);
+  });
+
+  it("surfaces a non-zero npm exit code as an error result", async () => {
+    const runCommand = vi.fn(async () => ({
+      exitCode: 1,
+      stdout: "",
+      stderr: "npm ERR! permission denied",
+    }));
+    const result = await upgradeNpmGlobal(baseOptions({ yes: true, runCommand }));
+
+    expect(result.status).toBe("error");
+    expect(result.error).toMatch(/permission denied|exit.*1/i);
+  });
+
+  it("returns error when getLatest resolves to null and no version pinned", async () => {
+    const result = await upgradeNpmGlobal(baseOptions({ getLatest: vi.fn(async () => null) }));
+    expect(result.status).toBe("error");
+    expect(result.error).toMatch(/latest/i);
+  });
+
+  it("bypasses getLatest when --version is pinned", async () => {
+    const getLatest = vi.fn();
+    const result = await upgradeNpmGlobal(
+      baseOptions({ check: true, version: "v0.35.0", getLatest })
+    );
+
+    expect(result.status).toBe("guidance");
+    expect(result.message).toContain("@0.35.0");
+    expect(result.toVersion).toBe("0.35.0");
+    expect(getLatest).not.toHaveBeenCalled();
+  });
+});

--- a/src/upgrade/apply-npm.ts
+++ b/src/upgrade/apply-npm.ts
@@ -39,7 +39,10 @@ function stripV(tag: string): string {
   return tag.startsWith("v") ? tag.slice(1) : tag;
 }
 
-async function defaultRunCommand(command: string, args: string[]): Promise<RunCommandResult> {
+export async function defaultRunCommand(
+  command: string,
+  args: string[]
+): Promise<RunCommandResult> {
   try {
     const { stdout, stderr } = await execFileAsync(command, args, { encoding: "utf-8" });
     return { exitCode: 0, stdout, stderr };
@@ -49,6 +52,13 @@ async function defaultRunCommand(command: string, args: string[]): Promise<RunCo
       stdout?: string;
       stderr?: string;
     };
+    if (err.code === "ENOENT") {
+      return {
+        exitCode: 127,
+        stdout: "",
+        stderr: `${command} not found in PATH — install Node.js to use the npm-global upgrade path`,
+      };
+    }
     const exitCode = typeof err.code === "number" ? err.code : 1;
     return {
       exitCode,

--- a/src/upgrade/apply-npm.ts
+++ b/src/upgrade/apply-npm.ts
@@ -1,0 +1,128 @@
+/**
+ * npm-global upgrade strategy.
+ *
+ * Without `--yes`: prints the exact `npm i -g …` command and exits without
+ * mutating anything. With `--yes`: runs the command directly.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { UpgradeResult } from "./apply-binary.js";
+import { type ReleaseInfo, getLatestVersion } from "./check.js";
+
+const execFileAsync = promisify(execFile);
+
+const PACKAGE_NAME = "@ncukondo/reference-manager";
+
+export interface RunCommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface UpgradeNpmOptions {
+  currentVersion: string;
+  /** Explicit tag like "v0.34.0" or "0.34.0". Defaults to the getLatest result. */
+  version?: string;
+  /** `--check`: report only, no action. */
+  check?: boolean;
+  /** `--yes`: run npm instead of printing the command. */
+  yes?: boolean;
+  /** Injection points. */
+  getLatest?: () => Promise<ReleaseInfo | null>;
+  runCommand?: (command: string, args: string[]) => Promise<RunCommandResult>;
+}
+
+export type { UpgradeResult };
+
+function stripV(tag: string): string {
+  return tag.startsWith("v") ? tag.slice(1) : tag;
+}
+
+async function defaultRunCommand(command: string, args: string[]): Promise<RunCommandResult> {
+  try {
+    const { stdout, stderr } = await execFileAsync(command, args, { encoding: "utf-8" });
+    return { exitCode: 0, stdout, stderr };
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException & {
+      code?: number | string;
+      stdout?: string;
+      stderr?: string;
+    };
+    const exitCode = typeof err.code === "number" ? err.code : 1;
+    return {
+      exitCode,
+      stdout: err.stdout ?? "",
+      stderr: err.stderr ?? err.message ?? "",
+    };
+  }
+}
+
+export async function upgradeNpmGlobal(options: UpgradeNpmOptions): Promise<UpgradeResult> {
+  const {
+    currentVersion,
+    version: pinnedVersion,
+    check = false,
+    yes = false,
+    getLatest = getLatestVersion,
+    runCommand = defaultRunCommand,
+  } = options;
+
+  let targetVersion: string;
+  let specifier: string;
+  if (pinnedVersion) {
+    targetVersion = stripV(pinnedVersion);
+    specifier = targetVersion;
+  } else {
+    const release = await getLatest();
+    if (!release) {
+      return {
+        status: "error",
+        fromVersion: currentVersion,
+        error: "Could not determine the latest release. Check your network connection.",
+      };
+    }
+    targetVersion = stripV(release.latest);
+    specifier = "latest";
+  }
+
+  const commandArgs = ["i", "-g", `${PACKAGE_NAME}@${specifier}`];
+  const commandLine = `npm ${commandArgs.join(" ")}`;
+
+  if (!pinnedVersion && currentVersion === targetVersion && !check) {
+    return {
+      status: "already-up-to-date",
+      fromVersion: currentVersion,
+      toVersion: targetVersion,
+      message: commandLine,
+    };
+  }
+
+  if (check || !yes) {
+    return {
+      status: "guidance",
+      fromVersion: currentVersion,
+      toVersion: targetVersion,
+      message: commandLine,
+    };
+  }
+
+  const result = await runCommand("npm", commandArgs);
+  if (result.exitCode !== 0) {
+    const details = result.stderr.trim() || result.stdout.trim();
+    return {
+      status: "error",
+      fromVersion: currentVersion,
+      toVersion: targetVersion,
+      message: commandLine,
+      error: `npm exited with code ${result.exitCode}${details ? `: ${details}` : ""}`,
+    };
+  }
+
+  return {
+    status: "success",
+    fromVersion: currentVersion,
+    toVersion: targetVersion,
+    message: commandLine,
+  };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,6 +41,7 @@ export default defineConfig({
         "node:buffer",
         "node:readline",
         "node:module",
+        "node:util",
         "@citation-js/core",
         "@citation-js/plugin-bibtex",
         "@citation-js/plugin-csl",


### PR DESCRIPTION
## Summary

- Adds `upgradeBinary` (Step 4) — downloads the platform asset, verifies via `--version`, atomically replaces (Unix) or rotates to `.old` (Windows).
- Adds `upgradeNpmGlobal` (Step 5) — prints `npm i -g @ncukondo/reference-manager@latest`, or runs it with `--yes`; surfaces non-zero npm exits as errors.
- Wires both strategies behind a `ref upgrade` Commander subcommand (Step 6) that dispatches via `detectInstallMethod()` (introduced in Stage 1 / #96) and prints guidance + exit 2 for `dev` / `npx` installs.
- Adds `rewriteUpgradeVersionFlag()` in the CLI entry so `ref upgrade --version <tag>` works with a space; without it the root program's `.version()` would intercept the flag.
- Externalizes `node:util` in `vite.config.ts` for the new `promisify(execFile)` usage.
- README gets an "Upgrading" section; CHANGELOG gets an [Unreleased] entry covering both stages.

Stage 1 (update-check notifier, install-method detection) already shipped in #96.

Closes #95

## Test plan

- [x] `npm run test:unit` — 3515 passed
- [x] `npm run test:e2e` — 3811 passed
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] Manual: `node bin/cli.js upgrade --help` shows all four options
- [x] Manual: `node bin/cli.js upgrade --check --version v0.0.0` reaches the subcommand (does not trigger root `--version`)
- [x] Manual: `node bin/cli.js --version` still prints the root version
- [ ] Manual TTY (requires real terminal):
  - [ ] Run `ref upgrade` on a `~/.local/bin/ref` install — verify atomic replace + new `--version`
  - [ ] Run `ref upgrade` on an `npm i -g` install — verify the command is shown (and run with `--yes`)
  - [ ] Run `ref upgrade` inside an `npm link`'d repo — verify exit 2 with guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)