### PR TITLE
feat(tui): redesign action menu — add Show, rename Output to Export (#92)

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,10 +622,10 @@ ref search -t "machine learning" # Pre-fill the search query
 - Real-time filtering as you type (200ms debounce)
 - Multi-select with Space key
 - Action menu for selected references:
-  - Output IDs (citation keys)
-  - Output as CSL-JSON
-  - Output as BibTeX
-  - Generate citation (APA or choose style)
+  - Show details (single selection)
+  - Citation keys (Pandoc or LaTeX)
+  - Cite (default style or choose style)
+  - Export (IDs, CSL-JSON, BibTeX, YAML)
 
 **Navigation:**
 | Key | Action |

--- a/spec/features/interactive-search.md
+++ b/spec/features/interactive-search.md
@@ -97,14 +97,15 @@ actions not available for multiple entries.
 
 ```
 ? Action for 1 selected reference:
-❯ Citation key (Pandoc)
-  Generate citation
-  Generate citation (choose style)
+❯ Show details
+  Citation key (Pandoc)
+  Cite
+  Cite (choose style)
   Open URL
   Open fulltext
-  Manage attachments
   Edit reference
-  Output (choose format)
+  Manage attachments
+  Export (choose format)
   Remove
   Cancel
 ```
@@ -118,17 +119,17 @@ The "Citation key" label shows the current format from `config.citation.defaultK
 ```
 ? Action for 3 selected references:
 ❯ Citation keys (Pandoc)
-  Generate citation
-  Generate citation (choose style)
+  Cite
+  Cite (choose style)
   Edit references
-  Output (choose format)
+  Export (choose format)
   Remove
   Cancel
 ```
 
 #### Output Format Submenu
 
-When "Output (choose format)" is selected:
+When "Export (choose format)" is selected:
 
 ```
 ? Output format:
@@ -145,13 +146,14 @@ When "Output (choose format)" is selected:
 
 | Action | Output |
 |--------|--------|
+| Show details | `ref show` pretty format for the selected reference (single only) |
 | Citation key | Pandoc: `@id` (single), `@id1; @id2` (multi). LaTeX: `\cite{id}` (single), `\cite{id1,id2}` (multi) |
-| Generate citation | Formatted citations using `config.citation.defaultStyle` |
-| Generate citation (choose) | Prompt for style, then generate |
-| Output IDs | Citation keys, one per line |
-| Output CSL-JSON | JSON array of selected references |
-| Output BibTeX | BibTeX entries |
-| Output YAML | YAML formatted references |
+| Cite | Formatted citations using `config.citation.defaultStyle` |
+| Cite (choose style) | Prompt for style, then generate |
+| Export IDs | Citation keys, one per line |
+| Export CSL-JSON | JSON array of selected references |
+| Export BibTeX | BibTeX entries |
+| Export YAML | YAML formatted references |
 
 **Side-effect actions** — perform an operation, then exit:
 

--- a/src/cli/commands/search.test.ts
+++ b/src/cli/commands/search.test.ts
@@ -353,6 +353,41 @@ describe("search command", () => {
     });
   });
 
+  describe("executeShowAction", () => {
+    it("should render the show pretty format for the first selected item", async () => {
+      const { executeShowAction } = await import("./search.js");
+
+      const item: CslItem = {
+        id: "ref1",
+        type: "article-journal",
+        title: "Test Article 1",
+        author: [{ family: "Smith", given: "John" }],
+        issued: { "date-parts": [[2023]] },
+        custom: { uuid: "uuid-1" },
+      };
+      const config = {
+        attachments: { directory: "/tmp/test-attachments" },
+      } as unknown as Config;
+
+      const output = await executeShowAction([item], config);
+
+      expect(output).toContain("[ref1] Test Article 1");
+      expect(output).toContain("Type:");
+      expect(output).toContain("article-journal");
+      expect(output).toContain("Smith, J.");
+    });
+
+    it("should return empty string when no items are selected", async () => {
+      const { executeShowAction } = await import("./search.js");
+
+      const config = {
+        attachments: { directory: "/tmp/test-attachments" },
+      } as unknown as Config;
+
+      expect(await executeShowAction([], config)).toBe("");
+    });
+  });
+
   describe("executeSideEffectAction", () => {
     const createItem = (id: string, overrides?: Partial<CslItem>): CslItem => ({
       id,

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -282,6 +282,12 @@ export async function executeInteractiveSearch(
     })
   );
 
+  // Handle show action: render the reference detail view (same flow as output actions)
+  if (result.action === "show" && result.selectedItems && !result.cancelled) {
+    const output = await executeShowAction(result.selectedItems, config);
+    return { output, cancelled: false, action: result.action };
+  }
+
   // Handle side-effect actions
   if (result.selectedItems && !result.cancelled) {
     const { isSideEffectAction } = await import("../../features/interactive/action-menu.js");
@@ -296,6 +302,18 @@ export async function executeInteractiveSearch(
     cancelled: result.cancelled,
     action: result.action,
   };
+}
+
+/**
+ * Execute the "show" action from the TUI action menu.
+ * Renders the reference detail view using the `ref show` pretty format.
+ * @internal Exported for testing only.
+ */
+export async function executeShowAction(items: CslItem[], config: Config): Promise<string> {
+  const item = items[0];
+  if (!item) return "";
+  const { formatShowOutput } = await import("./show.js");
+  return formatShowOutput(item, {}, config.attachments.directory);
 }
 
 /**

--- a/src/features/interactive/action-menu.test.ts
+++ b/src/features/interactive/action-menu.test.ts
@@ -32,6 +32,7 @@ describe("ACTION_CHOICES", () => {
   it("has all required action types", () => {
     const actionTypes = ACTION_CHOICES.map((c) => c.value);
 
+    expect(actionTypes).toContain("show");
     expect(actionTypes).toContain("key-default");
     expect(actionTypes).toContain("cite-default");
     expect(actionTypes).toContain("cite-choose");
@@ -140,6 +141,11 @@ describe("generateOutput", () => {
     expect(output).toBe("");
   });
 
+  it("should return empty string for show (executed by the CLI after TUI exit)", () => {
+    const output = generateOutput("show", mockItems);
+    expect(output).toBe("");
+  });
+
   it("should return empty string for side-effect actions", () => {
     const sideEffectActions: ActionType[] = [
       "open-url",
@@ -157,24 +163,49 @@ describe("generateOutput", () => {
 
 describe("getActionChoices", () => {
   describe("single entry (count=1)", () => {
-    it("should include all single-entry actions", () => {
-      const choices = getActionChoices(1);
-      const values = choices.map((c) => c.value);
+    it("should match the redesigned menu order", () => {
+      const values = getActionChoices(1).map((c) => c.value);
 
-      expect(values).toContain("key-default");
-      expect(values).toContain("cite-default");
-      expect(values).toContain("cite-choose");
-      expect(values).toContain("open-url");
-      expect(values).toContain("open-fulltext");
-      expect(values).toContain("manage-attachments");
-      expect(values).toContain("edit");
-      expect(values).toContain("output-format");
-      expect(values).toContain("remove");
-      expect(values).toContain("cancel");
+      expect(values).toEqual([
+        "show",
+        "key-default",
+        "cite-default",
+        "cite-choose",
+        "open-url",
+        "open-fulltext",
+        "edit",
+        "manage-attachments",
+        "output-format",
+        "remove",
+        "cancel",
+      ]);
     });
 
-    it("should have 10 choices for single entry", () => {
-      expect(getActionChoices(1)).toHaveLength(10);
+    it("should use the redesigned labels", () => {
+      const labels = getActionChoices(1).map((c) => c.label);
+
+      expect(labels).toEqual([
+        "Show details",
+        "Citation key (Pandoc)",
+        "Cite",
+        "Cite (choose style)",
+        "Open URL",
+        "Open fulltext",
+        "Edit reference",
+        "Manage attachments",
+        "Export (choose format)",
+        "Remove",
+        "Cancel",
+      ]);
+    });
+
+    it("should have 11 choices for single entry", () => {
+      expect(getActionChoices(1)).toHaveLength(11);
+    });
+
+    it("should place Show details at the top", () => {
+      const choices = getActionChoices(1);
+      expect(choices[0]).toEqual({ label: "Show details", value: "show" });
     });
 
     it("should show singular labels for single entry", () => {
@@ -201,22 +232,38 @@ describe("getActionChoices", () => {
       const choices = getActionChoices(3);
       const values = choices.map((c) => c.value);
 
+      expect(values).not.toContain("show");
       expect(values).not.toContain("open-url");
       expect(values).not.toContain("open-fulltext");
       expect(values).not.toContain("manage-attachments");
     });
 
-    it("should include multi-entry actions", () => {
-      const choices = getActionChoices(3);
-      const values = choices.map((c) => c.value);
+    it("should match the redesigned menu order", () => {
+      const values = getActionChoices(3).map((c) => c.value);
 
-      expect(values).toContain("key-default");
-      expect(values).toContain("cite-default");
-      expect(values).toContain("cite-choose");
-      expect(values).toContain("edit");
-      expect(values).toContain("output-format");
-      expect(values).toContain("remove");
-      expect(values).toContain("cancel");
+      expect(values).toEqual([
+        "key-default",
+        "cite-default",
+        "cite-choose",
+        "edit",
+        "output-format",
+        "remove",
+        "cancel",
+      ]);
+    });
+
+    it("should use the redesigned labels", () => {
+      const labels = getActionChoices(3).map((c) => c.label);
+
+      expect(labels).toEqual([
+        "Citation keys (Pandoc)",
+        "Cite",
+        "Cite (choose style)",
+        "Edit references",
+        "Export (choose format)",
+        "Remove",
+        "Cancel",
+      ]);
     });
 
     it("should have 7 choices for multiple entries", () => {
@@ -250,6 +297,7 @@ describe("isSideEffectAction", () => {
   });
 
   it("should return false for output actions", () => {
+    expect(isSideEffectAction("show")).toBe(false);
     expect(isSideEffectAction("key-default")).toBe(false);
     expect(isSideEffectAction("cite-default")).toBe(false);
     expect(isSideEffectAction("cite-choose")).toBe(false);

--- a/src/features/interactive/action-menu.ts
+++ b/src/features/interactive/action-menu.ts
@@ -17,6 +17,7 @@ import { Select, type SelectOption } from "./components/index.js";
  * Action types available in the action menu.
  */
 export type ActionType =
+  | "show"
   | "key-default"
   | "cite-default"
   | "cite-choose"
@@ -109,23 +110,33 @@ export function getActionChoices(
 
   const keyLabel = isSingle ? `Citation key (${formatLabel})` : `Citation keys (${formatLabel})`;
 
-  const choices: SelectOption<ActionType>[] = [
+  const choices: SelectOption<ActionType>[] = [];
+
+  if (isSingle) {
+    choices.push({ label: "Show details", value: "show" });
+  }
+
+  choices.push(
     { label: keyLabel, value: "key-default" },
-    { label: "Generate citation", value: "cite-default" },
-    { label: "Generate citation (choose style)", value: "cite-choose" },
-  ];
+    { label: "Cite", value: "cite-default" },
+    { label: "Cite (choose style)", value: "cite-choose" }
+  );
 
   if (isSingle) {
     choices.push(
       { label: "Open URL", value: "open-url" },
-      { label: "Open fulltext", value: "open-fulltext" },
-      { label: "Manage attachments", value: "manage-attachments" }
+      { label: "Open fulltext", value: "open-fulltext" }
     );
   }
 
+  choices.push({ label: isSingle ? "Edit reference" : "Edit references", value: "edit" });
+
+  if (isSingle) {
+    choices.push({ label: "Manage attachments", value: "manage-attachments" });
+  }
+
   choices.push(
-    { label: isSingle ? "Edit reference" : "Edit references", value: "edit" },
-    { label: "Output (choose format)", value: "output-format" },
+    { label: "Export (choose format)", value: "output-format" },
     { label: "Remove", value: "remove" },
     { label: "Cancel", value: "cancel" }
   );
@@ -242,6 +253,8 @@ export function generateOutput(
       }
       return items.map((i) => `@${i.id}`).join("; ");
 
+    // show is executed by the caller after TUI exit (needs library/attachments config)
+    case "show":
     case "cancel":
       return "";
 
@@ -331,8 +344,8 @@ async function processAction(
     };
   }
 
-  // Handle side-effect actions
-  if (isSideEffectAction(action)) {
+  // Handle show and side-effect actions: executed by the caller with selected items
+  if (action === "show" || isSideEffectAction(action)) {
     return {
       action,
       output: "",

--- a/src/features/interactive/apps/SearchFlowApp.tsx
+++ b/src/features/interactive/apps/SearchFlowApp.tsx
@@ -117,6 +117,12 @@ export function SearchFlowApp({
       return;
     }
 
+    // Show details: executed by the CLI after TUI exit (needs attachments config)
+    if (action === "show") {
+      exitWith({ action, output: "", cancelled: false, selectedItems });
+      return;
+    }
+
     // If cite-choose, go to style selection
     if (action === "cite-choose") {
       setState("style");


### PR DESCRIPTION
## Summary

Redesigns the TUI action menu (`ref search -t`) per issue #92. Backward compatibility is not a concern (pre-release).

### Changes

- **Add "Show details"** (single selection only, top of menu): renders the `ref show` pretty format to stdout after TUI exit, reusing `formatShowOutput` from the show command. Wired end-to-end: new `"show"` `ActionType` → `getActionChoices()` → `SearchFlowApp` exits with selected items → `executeShowAction()` in the search command renders the detail view.
- **Rename "Generate citation" → "Cite"** and **"Generate citation (choose style)" → "Cite (choose style)"**.
- **Rename "Output (choose format)" → "Export (choose format)"**.
- **Reorder**: "Edit reference" now comes before "Manage attachments"; menu composition/order for single and multi selection matches the issue proposal exactly.
- Docs updated: `spec/features/interactive-search.md`, README TUI section.

### Testing

- TDD: unit tests assert exact menu order and labels for single/multi selection, `isSideEffectAction("show") === false`, and `executeShowAction` output.
- Full unit suite: 3518 passed (4 pre-existing failures in `src/config/loader.test.ts` also fail on `main`, environment-related; unrelated to this change).
- `interactive-search.e2e.test.ts`: 12/12 passed after build.
- Typecheck and lint (biome): clean.
- Manually verified end-to-end by driving the built CLI in a PTY: Tab-select → Enter → "Show details" prints the reference detail view and exits 0; menu renders exactly as proposed.

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019JFb6y13iovMDoQhhPFTnV