### PR TITLE
feat(duplicate): add ERIC ID / Scopus ID exact-match duplicate detection (#98)

### DIFF
--- a/spec/features/add.md
+++ b/spec/features/add.md
@@ -102,7 +102,7 @@ arXiv ID is stored in `custom.arxiv_id`. The `DOI` field receives the journal DO
 
 ### Duplicate Detection
 
-- Default: Reject if duplicate found (DOI, PMID, or Title+Author+Year match)
+- Default: Reject if duplicate found (DOI, PMID, ISBN, arXiv ID, ERIC ID, Scopus ID, or Title+Author+Year match; see `spec/features/duplicate-detection.md`)
 - `--force`: Skip duplicate check
 
 ### ID Collision Handling

--- a/spec/features/duplicate-detection.md
+++ b/spec/features/duplicate-detection.md
@@ -5,7 +5,10 @@
 1. DOI
 2. PMID
 3. ISBN (with type-based rules)
-4. Title + Authors + Year
+4. arXiv ID (`custom.arxiv_id`, version suffix ignored)
+5. ERIC ID (`custom.eric_id`, exact match)
+6. Scopus ID (`custom.scopus_id`, exact match)
+7. Title + Authors + Year
 
 ## ISBN Matching Rules
 

--- a/spec/features/json-output.md
+++ b/spec/features/json-output.md
@@ -107,7 +107,7 @@ interface AddJsonOutput {
       "source": "10.1000/existing",
       "reason": "duplicate",
       "existingId": "existing-2024",
-      "duplicateType": "doi"  // or "pmid", "isbn", "isbn-title", "title-author-year"
+      "duplicateType": "doi"  // or "pmid", "isbn", "isbn-title", "arxiv", "eric", "scopus", "title-author-year"
     }
   ],
   "failed": [

--- a/spec/features/metadata.md
+++ b/spec/features/metadata.md
@@ -106,6 +106,8 @@
   - `additional_urls`: Optional array of additional URLs (optional)
   - `tags`: User-defined tags for categorization and search (optional, array of strings)
   - `arxiv_id`: arXiv identifier (optional, e.g. `"2301.13867"`)
+  - `eric_id`: ERIC identifier (optional, e.g. `"EJ1234567"`)
+  - `scopus_id`: Scopus identifier (optional, e.g. `"2-s2.0-85123456789"`)
   - `attachments`: Attachment metadata (optional, see `attachments.md`)
     - `directory`: Directory name relative to attachments base
     - `files`: Array of `{ filename, role, label? }` objects

--- a/src/core/csl-json/types.test.ts
+++ b/src/core/csl-json/types.test.ts
@@ -30,6 +30,42 @@ describe("CslCustomSchema typed fields", () => {
     });
   });
 
+  describe("eric_id", () => {
+    it("accepts eric_id string", () => {
+      const result = CslItemSchema.parse({
+        ...baseItem,
+        custom: { eric_id: "EJ1234567" },
+      });
+      expect(result.custom?.eric_id).toBe("EJ1234567");
+    });
+
+    it("is optional", () => {
+      const result = CslItemSchema.parse({
+        ...baseItem,
+        custom: {},
+      });
+      expect(result.custom?.eric_id).toBeUndefined();
+    });
+  });
+
+  describe("scopus_id", () => {
+    it("accepts scopus_id string", () => {
+      const result = CslItemSchema.parse({
+        ...baseItem,
+        custom: { scopus_id: "2-s2.0-85123456789" },
+      });
+      expect(result.custom?.scopus_id).toBe("2-s2.0-85123456789");
+    });
+
+    it("is optional", () => {
+      const result = CslItemSchema.parse({
+        ...baseItem,
+        custom: {},
+      });
+      expect(result.custom?.scopus_id).toBeUndefined();
+    });
+  });
+
   describe("attachments", () => {
     it("accepts valid attachments object", () => {
       const result = CslItemSchema.parse({
@@ -166,6 +202,24 @@ describe("CslCustomSchema typed fields", () => {
         CslItemSchema.parse({
           ...baseItem,
           custom: { arxiv_id: 12345 },
+        })
+      ).toThrow();
+    });
+
+    it("rejects non-string eric_id", () => {
+      expect(() =>
+        CslItemSchema.parse({
+          ...baseItem,
+          custom: { eric_id: 12345 },
+        })
+      ).toThrow();
+    });
+
+    it("rejects non-string scopus_id", () => {
+      expect(() =>
+        CslItemSchema.parse({
+          ...baseItem,
+          custom: { scopus_id: 12345 },
         })
       ).toThrow();
     });

--- a/src/core/csl-json/types.ts
+++ b/src/core/csl-json/types.ts
@@ -58,6 +58,8 @@ const CslCustomSchema = z
     additional_urls: z.array(z.string()).optional(),
     tags: z.array(z.string()).optional(),
     arxiv_id: z.string().optional(),
+    eric_id: z.string().optional(),
+    scopus_id: z.string().optional(),
     attachments: AttachmentsSchema.optional(),
     check: CheckDataSchema.optional(),
   })

--- a/src/features/duplicate/detector.test.ts
+++ b/src/features/duplicate/detector.test.ts
@@ -438,6 +438,178 @@ describe("detectDuplicate", () => {
     });
   });
 
+  describe("ERIC ID-based detection (fifth priority)", () => {
+    const ericOriginal: CslItem = {
+      id: "eric2023",
+      type: "article-journal",
+      title: "ERIC Paper on Education",
+      author: [{ family: "Brown", given: "Carol" }],
+      custom: {
+        uuid: "660e8400-e29b-41d4-a716-446655440101",
+        timestamp: "2024-01-01T00:00:00.000Z",
+        eric_id: "EJ1234567",
+      },
+    };
+
+    it("should detect duplicate by ERIC ID", () => {
+      const newItem: CslItem = {
+        id: "new-eric",
+        type: "article-journal",
+        title: "Same ERIC Paper",
+        custom: { eric_id: "EJ1234567" },
+      };
+      const result = detectDuplicate(newItem, [ericOriginal]);
+
+      expect(result.isDuplicate).toBe(true);
+      expect(result.matches).toHaveLength(1);
+      expect(result.matches[0].type).toBe("eric");
+      expect(result.matches[0].details?.eric_id).toBe("EJ1234567");
+    });
+
+    it("should NOT detect duplicate when ERIC IDs differ", () => {
+      const newItem: CslItem = {
+        id: "different-eric",
+        type: "article-journal",
+        title: "Different ERIC Paper",
+        custom: { eric_id: "EJ7654321" },
+      };
+      const result = detectDuplicate(newItem, [ericOriginal]);
+
+      expect(result.isDuplicate).toBe(false);
+    });
+
+    it("should NOT match when item has no eric_id", () => {
+      const newItem: CslItem = {
+        id: "no-eric",
+        type: "article-journal",
+        title: "No ERIC ID",
+      };
+      const result = detectDuplicate(newItem, [ericOriginal]);
+
+      // Should not match on ERIC (may match on title-author-year)
+      const ericMatch = result.matches.find((m) => m.type === "eric");
+      expect(ericMatch).toBeUndefined();
+    });
+
+    it("should prioritize arXiv ID over ERIC ID", () => {
+      const ericWithArxiv: CslItem = {
+        ...ericOriginal,
+        custom: {
+          ...ericOriginal.custom,
+          arxiv_id: "2301.13867",
+        },
+      };
+      const newItem: CslItem = {
+        id: "arxiv-and-eric",
+        type: "article-journal",
+        title: "Paper with both",
+        custom: { arxiv_id: "2301.13867", eric_id: "EJ1234567" },
+      };
+      const result = detectDuplicate(newItem, [ericWithArxiv]);
+
+      expect(result.isDuplicate).toBe(true);
+      expect(result.matches[0].type).toBe("arxiv");
+    });
+
+    it("should prioritize ERIC ID over Title + Author + Year", () => {
+      const newItem: CslItem = {
+        ...ericOriginal,
+        id: "eric-and-tay",
+        custom: { eric_id: "EJ1234567" },
+      };
+      const result = detectDuplicate(newItem, [ericOriginal]);
+
+      expect(result.isDuplicate).toBe(true);
+      expect(result.matches[0].type).toBe("eric");
+    });
+  });
+
+  describe("Scopus ID-based detection (sixth priority)", () => {
+    const scopusOriginal: CslItem = {
+      id: "scopus2023",
+      type: "article-journal",
+      title: "Scopus Paper on Medicine",
+      author: [{ family: "Davis", given: "Erin" }],
+      custom: {
+        uuid: "660e8400-e29b-41d4-a716-446655440102",
+        timestamp: "2024-01-01T00:00:00.000Z",
+        scopus_id: "2-s2.0-85123456789",
+      },
+    };
+
+    it("should detect duplicate by Scopus ID", () => {
+      const newItem: CslItem = {
+        id: "new-scopus",
+        type: "article-journal",
+        title: "Same Scopus Paper",
+        custom: { scopus_id: "2-s2.0-85123456789" },
+      };
+      const result = detectDuplicate(newItem, [scopusOriginal]);
+
+      expect(result.isDuplicate).toBe(true);
+      expect(result.matches).toHaveLength(1);
+      expect(result.matches[0].type).toBe("scopus");
+      expect(result.matches[0].details?.scopus_id).toBe("2-s2.0-85123456789");
+    });
+
+    it("should NOT detect duplicate when Scopus IDs differ", () => {
+      const newItem: CslItem = {
+        id: "different-scopus",
+        type: "article-journal",
+        title: "Different Scopus Paper",
+        custom: { scopus_id: "2-s2.0-99999999999" },
+      };
+      const result = detectDuplicate(newItem, [scopusOriginal]);
+
+      expect(result.isDuplicate).toBe(false);
+    });
+
+    it("should NOT match when item has no scopus_id", () => {
+      const newItem: CslItem = {
+        id: "no-scopus",
+        type: "article-journal",
+        title: "No Scopus ID",
+      };
+      const result = detectDuplicate(newItem, [scopusOriginal]);
+
+      // Should not match on Scopus (may match on title-author-year)
+      const scopusMatch = result.matches.find((m) => m.type === "scopus");
+      expect(scopusMatch).toBeUndefined();
+    });
+
+    it("should prioritize ERIC ID over Scopus ID", () => {
+      const scopusWithEric: CslItem = {
+        ...scopusOriginal,
+        custom: {
+          ...scopusOriginal.custom,
+          eric_id: "EJ1234567",
+        },
+      };
+      const newItem: CslItem = {
+        id: "eric-and-scopus",
+        type: "article-journal",
+        title: "Paper with both",
+        custom: { eric_id: "EJ1234567", scopus_id: "2-s2.0-85123456789" },
+      };
+      const result = detectDuplicate(newItem, [scopusWithEric]);
+
+      expect(result.isDuplicate).toBe(true);
+      expect(result.matches[0].type).toBe("eric");
+    });
+
+    it("should prioritize Scopus ID over Title + Author + Year", () => {
+      const newItem: CslItem = {
+        ...scopusOriginal,
+        id: "scopus-and-tay",
+        custom: { scopus_id: "2-s2.0-85123456789" },
+      };
+      const result = detectDuplicate(newItem, [scopusOriginal]);
+
+      expect(result.isDuplicate).toBe(true);
+      expect(result.matches[0].type).toBe("scopus");
+    });
+  });
+
   describe("Title + Author + Year detection (lowest priority)", () => {
     it("should detect duplicate by title + author + year", () => {
       const result = detectDuplicate(duplicateTitleAuthorYear, [original]);

--- a/src/features/duplicate/detector.ts
+++ b/src/features/duplicate/detector.ts
@@ -198,6 +198,56 @@ function checkArxivMatch(item: CslItem, existing: CslItem): DuplicateMatch | nul
 }
 
 /**
+ * Check for ERIC ID match
+ */
+function checkEricMatch(item: CslItem, existing: CslItem): DuplicateMatch | null {
+  const itemEricId = item.custom?.eric_id;
+  const existingEricId = existing.custom?.eric_id;
+
+  if (!itemEricId || !existingEricId) {
+    return null;
+  }
+
+  // ERIC ID comparison is exact string match
+  if (itemEricId === existingEricId) {
+    return {
+      type: "eric",
+      existing,
+      details: {
+        eric_id: existingEricId,
+      },
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Check for Scopus ID match
+ */
+function checkScopusMatch(item: CslItem, existing: CslItem): DuplicateMatch | null {
+  const itemScopusId = item.custom?.scopus_id;
+  const existingScopusId = existing.custom?.scopus_id;
+
+  if (!itemScopusId || !existingScopusId) {
+    return null;
+  }
+
+  // Scopus ID comparison is exact string match
+  if (itemScopusId === existingScopusId) {
+    return {
+      type: "scopus",
+      existing,
+      details: {
+        scopus_id: existingScopusId,
+      },
+    };
+  }
+
+  return null;
+}
+
+/**
  * Check if two items match by Title + Author + Year
  */
 function checkTitleAuthorYearMatch(item: CslItem, existing: CslItem): DuplicateMatch | null {
@@ -264,7 +314,19 @@ function checkSingleDuplicate(item: CslItem, existing: CslItem): DuplicateMatch 
     return arxivMatch;
   }
 
-  // Priority 5: Title + Author + Year matching (lowest priority)
+  // Priority 5: ERIC ID matching
+  const ericMatch = checkEricMatch(item, existing);
+  if (ericMatch) {
+    return ericMatch;
+  }
+
+  // Priority 6: Scopus ID matching
+  const scopusMatch = checkScopusMatch(item, existing);
+  if (scopusMatch) {
+    return scopusMatch;
+  }
+
+  // Priority 7: Title + Author + Year matching (lowest priority)
   return checkTitleAuthorYearMatch(item, existing);
 }
 
@@ -274,7 +336,11 @@ function checkSingleDuplicate(item: CslItem, existing: CslItem): DuplicateMatch 
  * Priority order:
  * 1. DOI (highest priority)
  * 2. PMID
- * 3. Title + Author + Year (lowest priority)
+ * 3. ISBN
+ * 4. arXiv ID
+ * 5. ERIC ID
+ * 6. Scopus ID
+ * 7. Title + Author + Year (lowest priority)
  *
  * @param item - The reference to check for duplicates
  * @param existingReferences - Array of existing references to check against

--- a/src/features/duplicate/types.ts
+++ b/src/features/duplicate/types.ts
@@ -7,7 +7,15 @@ import type { CslItem } from "../../core/csl-json/types.js";
 /**
  * Type of duplicate match
  */
-export type DuplicateType = "doi" | "pmid" | "isbn" | "isbn-title" | "arxiv" | "title-author-year";
+export type DuplicateType =
+  | "doi"
+  | "pmid"
+  | "isbn"
+  | "isbn-title"
+  | "arxiv"
+  | "eric"
+  | "scopus"
+  | "title-author-year";
 
 /**
  * A single duplicate match result
@@ -31,6 +39,8 @@ export interface DuplicateMatch {
     pmid?: string;
     isbn?: string;
     arxiv_id?: string;
+    eric_id?: string;
+    scopus_id?: string;
     normalizedTitle?: string;
     normalizedAuthors?: string;
     year?: string;


### PR DESCRIPTION
## Summary

Adds ERIC ID and Scopus ID exact-match duplicate detection, so references imported with only `custom.eric_id` / `custom.scopus_id` identifiers (e.g. from search-hub, see ncukondo/search-hub#151) are deduplicated even when Title+Author+Year metadata is incomplete.

## Changes

- **`src/core/csl-json/types.ts`**: add `eric_id` / `scopus_id` as typed optional string fields on `CslCustomSchema` (previously only preserved via `.passthrough()`, now validated)
- **`src/features/duplicate/types.ts`**: add `"eric"` / `"scopus"` to `DuplicateType` and `eric_id` / `scopus_id` to `DuplicateMatch.details`
- **`src/features/duplicate/detector.ts`**: add `checkEricMatch` / `checkScopusMatch` (exact string match, same shape as `checkArxivMatch`), inserted after arXiv and before the Title+Author+Year fallback

New priority order: DOI → PMID → ISBN → arXiv → **ERIC** → **Scopus** → Title+Author+Year

## Spec updates

- `spec/features/duplicate-detection.md`: priority list now includes arXiv/ERIC/Scopus (arXiv was previously missing)
- `spec/features/metadata.md`: document `custom.eric_id` / `custom.scopus_id`
- `spec/features/json-output.md`: `duplicateType` enum comment updated
- `spec/features/add.md`: duplicate-detection criteria list updated

## Tests

- Schema tests: accept/optional/reject-non-string for both new fields
- Detector tests: exact match, no-match on differing IDs, no-match on missing field, and priority-order tests (arXiv > ERIC, ERIC > Scopus, ERIC/Scopus > Title+Author+Year)

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019JFb6y13iovMDoQhhPFTnV
