### PR TITLE
fix(upgrade): bypass stale update-check cache and resolve bunfs destPath

### DIFF
--- a/spec/features/self-upgrade.md
+++ b/spec/features/self-upgrade.md
@@ -68,6 +68,10 @@ Result is cached at `{data}/update-check.json`:
 - TTL: 24 hours
 - `{data}` resolves to the same platform-specific data dir used by the library (see `spec/architecture/cli.md`)
 - Cache is consulted before any network call; a fresh cache means no HTTP request
+- **The cache applies to the passive notifier only.** An explicit `ref upgrade` (including
+  `--check`) always queries the live GitHub Releases API (`getLatestVersion({ force: true })`)
+  so it never reports "already up to date" from a stale cache. A successful forced check
+  still refreshes the cache file.
 
 ### 2. `ref upgrade` command
 
@@ -76,6 +80,16 @@ ref upgrade [options]
 ```
 
 Detects the install method from `fs.realpathSync(process.argv[1])` and applies the appropriate strategy.
+
+#### bunfs / `execPath` resolution (Bun single-file executables)
+
+Inside a Bun single-file executable, `process.argv[1]` points into a virtual read-only
+filesystem (`/$bunfs/root/...` on POSIX, `B:\~BUN\root\...` on Windows). Those paths do not
+exist on disk and cannot be written to; the real on-disk binary is `process.execPath`.
+Before realpath/pattern-matching, both install-method detection and destination resolution
+substitute `process.execPath` when `argv[1]` is a bunfs virtual path (`isBunfsPath` /
+`resolveEntrypoint` in `src/upgrade/detect.ts`). `--install-dir` still takes precedence over
+the resolved destination. Non-bunfs invocations (node, npm-global, dev) are unaffected.
 
 | Install method | Detection heuristic | Action |
 |---|---|---|

--- a/spec/tasks/20260712-01-fix-upgrade-cache-and-bunfs.md
+++ b/spec/tasks/20260712-01-fix-upgrade-cache-and-bunfs.md
@@ -71,7 +71,7 @@ For each step, follow the Red-Green-Refactor cycle (see `spec/guidelines/testing
 
 ### Step 3: Spec update
 
-- [ ] Update `spec/features/self-upgrade.md`: explicit `ref upgrade`/`--check` always bypasses the
+- [x] Update `spec/features/self-upgrade.md`: explicit `ref upgrade`/`--check` always bypasses the
       cache (notifier keeps 24h TTL); document bunfs/execPath destination resolution
 
 ## Manual Verification

--- a/spec/tasks/20260712-01-fix-upgrade-cache-and-bunfs.md
+++ b/spec/tasks/20260712-01-fix-upgrade-cache-and-bunfs.md
@@ -57,17 +57,17 @@ For each step, follow the Red-Green-Refactor cycle (see `spec/guidelines/testing
 
 ### Step 2: Resolve real binary path inside Bun single-file executables
 
-- [ ] Write test: extend `src/upgrade/detect.test.ts` and `src/cli/commands/upgrade.test.ts` —
+- [x] Write test: extend `src/upgrade/detect.test.ts` and `src/cli/commands/upgrade.test.ts` —
       given `argv1 = "/$bunfs/root/ref-linux-x64"` and an `execPath` like `/home/user/.local/bin/ref`,
       detection returns `"binary"` deliberately (not by fall-through) and destPath resolves to the
       execPath location; non-bunfs behavior unchanged
-- [ ] Verify Red
-- [ ] Implement: add a bunfs-aware resolution helper (e.g. in `src/upgrade/detect.ts` or a shared
+- [x] Verify Red
+- [x] Implement: add a bunfs-aware resolution helper (e.g. in `src/upgrade/detect.ts` or a shared
       util): if `argv[1]` is a bunfs virtual path, substitute `process.execPath` before realpath /
       pattern-matching; wire into both `detectInstallMethod` and `resolveDestPath`; make `execPath`
       injectable for tests
-- [ ] Verify Green: `npm run test:unit -- upgrade detect`
-- [ ] Lint/Type check: `npm run lint && npm run typecheck`
+- [x] Verify Green: `npm run test:unit -- upgrade detect`
+- [x] Lint/Type check: `npm run lint && npm run typecheck`
 
 ### Step 3: Spec update
 

--- a/spec/tasks/20260712-01-fix-upgrade-cache-and-bunfs.md
+++ b/spec/tasks/20260712-01-fix-upgrade-cache-and-bunfs.md
@@ -46,14 +46,14 @@ For each step, follow the Red-Green-Refactor cycle (see `spec/guidelines/testing
 
 ### Step 1: Explicit upgrade bypasses the 24h cache
 
-- [ ] Write test: extend `src/upgrade/apply-binary.test.ts` and `src/upgrade/apply-npm.test.ts` —
+- [x] Write test: extend `src/upgrade/apply-binary.test.ts` and `src/upgrade/apply-npm.test.ts` —
       assert `getLatest` is invoked with `{ force: true }` (or that a fresh cache is ignored) when the
       upgrade command resolves the target version without a pinned `--version`
-- [ ] Verify Red
-- [ ] Implement: pass `force: true` through `upgradeBinary`/`upgradeNpmGlobal` default `getLatest`
+- [x] Verify Red
+- [x] Implement: pass `force: true` through `upgradeBinary`/`upgradeNpmGlobal` default `getLatest`
       (keep the injected-`getLatest` test seam working; the notifier path must remain cache-first)
-- [ ] Verify Green: `npm run test:unit -- upgrade`
-- [ ] Lint/Type check: `npm run lint && npm run typecheck`
+- [x] Verify Green: `npm run test:unit -- upgrade`
+- [x] Lint/Type check: `npm run lint && npm run typecheck`
 
 ### Step 2: Resolve real binary path inside Bun single-file executables
 

--- a/spec/tasks/20260712-01-fix-upgrade-cache-and-bunfs.md
+++ b/spec/tasks/20260712-01-fix-upgrade-cache-and-bunfs.md
@@ -1,0 +1,81 @@
+# Task: Fix `ref upgrade` stale-cache check and bunfs destPath resolution
+
+## Purpose
+
+Two bugs prevent `ref upgrade` from actually upgrading an installed single-binary `ref`.
+Both were reproduced on a real install (`~/.local/bin/ref`, Bun single-file ELF binary, 0.34.0 installed, v0.35.0 released):
+
+1. **Stale-cache bug**: `ref upgrade` reported `Already up to date (0.34.0)` even though v0.35.0 was
+   released, because the explicit upgrade command reuses the 24h update-notifier cache
+   (`{data}/update-check.json`). `upgradeBinary` (`src/upgrade/apply-binary.ts:132`) and
+   `upgradeNpmGlobal` (`src/upgrade/apply-npm.ts:87`) call `getLatest()` without `force`.
+   An explicit `ref upgrade` / `ref upgrade --check` must always query the live GitHub Releases API
+   (`getLatestVersion({ force: true })`). The passive startup notifier must keep using the cache as-is.
+
+2. **bunfs destPath bug**: after clearing the cache, `ref upgrade` failed with
+   `Failed to write downloaded binary: ENOENT: no such file or directory, open '/$bunfs/root/ref-linux-x64.tmp.<pid>'`.
+   Inside a Bun single-file executable, `process.argv[1]` resolves to a virtual read-only path
+   (`/$bunfs/root/...`), so `resolveDestPath` (`src/cli/commands/upgrade.ts:43`) picks an unwritable
+   virtual destination. The real on-disk binary path is `process.execPath`. Both destination
+   resolution and install-method detection (`detectInstallMethod` in `src/upgrade/detect.ts:76`,
+   which currently only falls through to "binary" by luck for bunfs paths) must use `process.execPath`
+   when `argv[1]` points into the bunfs virtual filesystem (path starts with `/$bunfs/` on POSIX,
+   `B:\~BUN\` or similar bunfs marker on Windows — check Bun docs/behavior and normalize).
+
+Workaround confirmed working: `rm {data}/update-check.json && ref upgrade --install-dir ~/.local/bin`
+upgraded 0.34.0 -> 0.35.0, so download/verify/atomic-replace machinery is sound. Only target
+resolution (cache) and destination resolution (bunfs) need fixing.
+
+## References
+
+- Spec: `spec/features/self-upgrade.md` (update it where behavior is clarified: explicit upgrade bypasses cache; bunfs/execPath resolution)
+- Related: `src/upgrade/check.ts`, `src/upgrade/apply-binary.ts`, `src/upgrade/apply-npm.ts`, `src/upgrade/detect.ts`, `src/cli/commands/upgrade.ts`
+
+## TDD Workflow
+
+For each step, follow the Red-Green-Refactor cycle (see `spec/guidelines/testing.md`):
+
+1. **Write test**: Create/extend test file with comprehensive test cases
+2. **Create stub**: Stub new functions (`throw new Error("Not implemented")`) where applicable
+3. **Verify Red**: Run tests, confirm they fail
+4. **Implement**: Write actual logic until tests pass (Green)
+5. **Refactor**: Clean up code while keeping tests green
+6. **Quality checks**: Pass lint/typecheck
+
+## Steps
+
+### Step 1: Explicit upgrade bypasses the 24h cache
+
+- [ ] Write test: extend `src/upgrade/apply-binary.test.ts` and `src/upgrade/apply-npm.test.ts` —
+      assert `getLatest` is invoked with `{ force: true }` (or that a fresh cache is ignored) when the
+      upgrade command resolves the target version without a pinned `--version`
+- [ ] Verify Red
+- [ ] Implement: pass `force: true` through `upgradeBinary`/`upgradeNpmGlobal` default `getLatest`
+      (keep the injected-`getLatest` test seam working; the notifier path must remain cache-first)
+- [ ] Verify Green: `npm run test:unit -- upgrade`
+- [ ] Lint/Type check: `npm run lint && npm run typecheck`
+
+### Step 2: Resolve real binary path inside Bun single-file executables
+
+- [ ] Write test: extend `src/upgrade/detect.test.ts` and `src/cli/commands/upgrade.test.ts` —
+      given `argv1 = "/$bunfs/root/ref-linux-x64"` and an `execPath` like `/home/user/.local/bin/ref`,
+      detection returns `"binary"` deliberately (not by fall-through) and destPath resolves to the
+      execPath location; non-bunfs behavior unchanged
+- [ ] Verify Red
+- [ ] Implement: add a bunfs-aware resolution helper (e.g. in `src/upgrade/detect.ts` or a shared
+      util): if `argv[1]` is a bunfs virtual path, substitute `process.execPath` before realpath /
+      pattern-matching; wire into both `detectInstallMethod` and `resolveDestPath`; make `execPath`
+      injectable for tests
+- [ ] Verify Green: `npm run test:unit -- upgrade detect`
+- [ ] Lint/Type check: `npm run lint && npm run typecheck`
+
+### Step 3: Spec update
+
+- [ ] Update `spec/features/self-upgrade.md`: explicit `ref upgrade`/`--check` always bypasses the
+      cache (notifier keeps 24h TTL); document bunfs/execPath destination resolution
+
+## Manual Verification
+
+Not scriptable in CI (requires a compiled Bun binary). Document in the PR body:
+the two reproduced failure outputs and, if feasible, a local `bun build --compile` smoke test
+showing `ref upgrade --check` reports the live latest version and resolves a writable destPath.

--- a/src/cli/commands/upgrade.test.ts
+++ b/src/cli/commands/upgrade.test.ts
@@ -159,6 +159,39 @@ describe("runUpgrade", () => {
     expect(firstCall?.[0].destPath).toContain("ref");
   });
 
+  it("resolves destPath from execPath when argv1 is a bunfs virtual path", async () => {
+    const upgradeBinaryFn = vi.fn(async () => okResult());
+    await runUpgrade(
+      {} as UpgradeCommandOptions,
+      defaultDeps({
+        installMethod: "binary",
+        argv1: "/$bunfs/root/ref-linux-x64",
+        execPath: "/home/user/.local/bin/ref",
+        upgradeBinaryFn,
+      })
+    );
+
+    const [firstCall] = upgradeBinaryFn.mock.calls;
+    expect(firstCall?.[0].destPath).toBe("/home/user/.local/bin/ref");
+  });
+
+  it("prefers --install-dir over execPath for a bunfs argv1", async () => {
+    const upgradeBinaryFn = vi.fn(async () => okResult());
+    await runUpgrade(
+      { installDir: "/opt/custom" } as UpgradeCommandOptions,
+      defaultDeps({
+        installMethod: "binary",
+        argv1: "/$bunfs/root/ref-linux-x64",
+        execPath: "/home/user/.local/bin/ref",
+        upgradeBinaryFn,
+      })
+    );
+
+    const [firstCall] = upgradeBinaryFn.mock.calls;
+    const expected = join("/opt/custom", process.platform === "win32" ? "ref.exe" : "ref");
+    expect(firstCall?.[0].destPath).toBe(expected);
+  });
+
   it("honors --install-dir override for the binary strategy", async () => {
     const upgradeBinaryFn = vi.fn(async () => okResult());
     await runUpgrade(

--- a/src/cli/commands/upgrade.ts
+++ b/src/cli/commands/upgrade.ts
@@ -14,7 +14,7 @@ import {
   upgradeBinary,
 } from "../../upgrade/apply-binary.js";
 import { type UpgradeNpmOptions, upgradeNpmGlobal } from "../../upgrade/apply-npm.js";
-import { type InstallMethod, detectInstallMethod } from "../../upgrade/detect.js";
+import { type InstallMethod, detectInstallMethod, isBunfsPath } from "../../upgrade/detect.js";
 import { ExitCode, setExitCode } from "../helpers.js";
 
 export interface UpgradeCommandOptions {
@@ -27,6 +27,8 @@ export interface UpgradeCommandOptions {
 export interface RunUpgradeDeps {
   installMethod?: InstallMethod;
   argv1?: string;
+  /** Defaults to `process.execPath`; replaces a bunfs virtual `argv1`. */
+  execPath?: string;
   currentVersion?: string;
   upgradeBinaryFn?: (options: UpgradeBinaryOptions) => Promise<UpgradeResult>;
   upgradeNpmFn?: (options: UpgradeNpmOptions) => Promise<UpgradeResult>;
@@ -40,15 +42,18 @@ export interface RunUpgradeResult {
   result?: UpgradeResult;
 }
 
-function resolveDestPath(argv1: string, installDir: string | undefined): string {
+function resolveDestPath(argv1: string, installDir: string | undefined, execPath: string): string {
   if (installDir) {
     const basename = process.platform === "win32" ? "ref.exe" : "ref";
     return join(installDir, basename);
   }
+  // A bunfs virtual argv1 is read-only and does not exist on disk; the real
+  // binary a Bun single-file executable runs from is execPath.
+  const source = isBunfsPath(argv1) ? execPath : argv1;
   try {
-    return realpathSync(argv1);
+    return realpathSync(source);
   } catch {
-    return argv1;
+    return source;
   }
 }
 
@@ -90,9 +95,10 @@ export function formatUpgradeResult(result: UpgradeResult): string {
 function buildBinaryOptions(
   options: UpgradeCommandOptions,
   argv1: string,
-  currentVersion: string
+  currentVersion: string,
+  execPath: string
 ): UpgradeBinaryOptions {
-  const destPath = resolveDestPath(argv1, options.installDir);
+  const destPath = resolveDestPath(argv1, options.installDir, execPath);
   const out: UpgradeBinaryOptions = { destPath, currentVersion };
   if (options.check !== undefined) out.check = options.check;
   if (options.version !== undefined) out.version = options.version;
@@ -114,7 +120,9 @@ export async function runUpgrade(
   options: UpgradeCommandOptions,
   deps: RunUpgradeDeps = {}
 ): Promise<RunUpgradeResult> {
-  const installMethod = deps.installMethod ?? detectInstallMethod(deps.argv1 ?? process.argv[1]);
+  const execPath = deps.execPath ?? process.execPath;
+  const installMethod =
+    deps.installMethod ?? detectInstallMethod(deps.argv1 ?? process.argv[1], execPath);
   const argv1 = deps.argv1 ?? process.argv[1] ?? "";
   const currentVersion = deps.currentVersion ?? packageJson.version;
   const upgradeBinaryFn = deps.upgradeBinaryFn ?? upgradeBinary;
@@ -129,7 +137,7 @@ export async function runUpgrade(
 
   const result =
     installMethod === "binary"
-      ? await upgradeBinaryFn(buildBinaryOptions(options, argv1, currentVersion))
+      ? await upgradeBinaryFn(buildBinaryOptions(options, argv1, currentVersion, execPath))
       : await upgradeNpmFn(buildNpmOptions(options, currentVersion));
 
   const target = result.status === "error" ? stderr : stdout;

--- a/src/upgrade/apply-binary.test.ts
+++ b/src/upgrade/apply-binary.test.ts
@@ -99,6 +99,32 @@ describe("upgradeBinary", () => {
     expect(verifyCalls).toEqual([`${destPath}.tmp.12345`]);
   });
 
+  it("calls getLatest with force=true so an explicit upgrade bypasses the 24h cache", async () => {
+    const getLatest = vi.fn(async () => ({
+      checkedAt: "2026-04-20T12:00:00Z",
+      latest: "0.34.0",
+      url: "https://github.com/ncukondo/reference-manager/releases/tag/v0.34.0",
+    }));
+
+    const result = await upgradeBinary(baseOptions({ getLatest }));
+
+    expect(result.status).toBe("success");
+    expect(getLatest).toHaveBeenCalledWith({ force: true });
+  });
+
+  it("calls getLatest with force=true in check mode too", async () => {
+    const getLatest = vi.fn(async () => ({
+      checkedAt: "2026-04-20T12:00:00Z",
+      latest: "0.34.0",
+      url: "https://github.com/ncukondo/reference-manager/releases/tag/v0.34.0",
+    }));
+
+    const result = await upgradeBinary(baseOptions({ check: true, getLatest }));
+
+    expect(result.status).toBe("guidance");
+    expect(getLatest).toHaveBeenCalledWith({ force: true });
+  });
+
   it("uses `--version <tag>` when provided, bypassing getLatest", async () => {
     const getLatest = vi.fn();
     const fetchFn = vi.fn(async (url: URL | string) => {

--- a/src/upgrade/apply-binary.ts
+++ b/src/upgrade/apply-binary.ts
@@ -45,7 +45,7 @@ export interface UpgradeBinaryOptions {
   pid?: number;
   /** Injection points. */
   fetch?: typeof globalThis.fetch;
-  getLatest?: () => Promise<ReleaseInfo | null>;
+  getLatest?: (options?: { force?: boolean }) => Promise<ReleaseInfo | null>;
   /**
    * Runs the downloaded binary's `--version` command and returns the stdout
    * (or null on failure). Injected so unit tests don't execute real children.
@@ -123,13 +123,15 @@ interface ResolvedTarget {
 
 async function resolveTarget(
   pinnedVersion: string | undefined,
-  getLatest: () => Promise<ReleaseInfo | null>
+  getLatest: (options?: { force?: boolean }) => Promise<ReleaseInfo | null>
 ): Promise<ResolvedTarget | { error: string }> {
   if (pinnedVersion) {
     const targetTag = normalizeTag(pinnedVersion);
     return { targetTag, targetVersion: stripV(targetTag) };
   }
-  const release = await getLatest();
+  // Explicit `ref upgrade` must see the live latest release; only the passive
+  // startup notifier is allowed to reuse the 24h cache.
+  const release = await getLatest({ force: true });
   if (!release) {
     return { error: "Could not determine the latest release. Check your network connection." };
   }

--- a/src/upgrade/apply-npm.test.ts
+++ b/src/upgrade/apply-npm.test.ts
@@ -25,6 +25,19 @@ describe("upgradeNpmGlobal", () => {
     expect(runCommand).not.toHaveBeenCalled();
   });
 
+  it("calls getLatest with force=true so an explicit upgrade bypasses the 24h cache", async () => {
+    const getLatest = vi.fn(async () => ({
+      checkedAt: "2026-04-20T12:00:00Z",
+      latest: "0.34.0",
+      url: "https://github.com/ncukondo/reference-manager/releases/tag/v0.34.0",
+    }));
+
+    const result = await upgradeNpmGlobal(baseOptions({ getLatest }));
+
+    expect(result.status).toBe("guidance");
+    expect(getLatest).toHaveBeenCalledWith({ force: true });
+  });
+
   it("returns already-up-to-date when latest equals current version", async () => {
     const runCommand = vi.fn();
     const result = await upgradeNpmGlobal(baseOptions({ currentVersion: "0.34.0", runCommand }));

--- a/src/upgrade/apply-npm.ts
+++ b/src/upgrade/apply-npm.ts
@@ -29,7 +29,7 @@ export interface UpgradeNpmOptions {
   /** `--yes`: run npm instead of printing the command. */
   yes?: boolean;
   /** Injection points. */
-  getLatest?: () => Promise<ReleaseInfo | null>;
+  getLatest?: (options?: { force?: boolean }) => Promise<ReleaseInfo | null>;
   runCommand?: (command: string, args: string[]) => Promise<RunCommandResult>;
 }
 
@@ -84,7 +84,9 @@ export async function upgradeNpmGlobal(options: UpgradeNpmOptions): Promise<Upgr
     targetVersion = stripV(pinnedVersion);
     specifier = targetVersion;
   } else {
-    const release = await getLatest();
+    // Explicit `ref upgrade` must see the live latest release; only the
+    // passive startup notifier is allowed to reuse the 24h cache.
+    const release = await getLatest({ force: true });
     if (!release) {
       return {
         status: "error",

--- a/src/upgrade/detect.test.ts
+++ b/src/upgrade/detect.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { detectInstallMethod } from "./detect.js";
+import { detectInstallMethod, isBunfsPath } from "./detect.js";
 
 describe("detectInstallMethod", () => {
   let testDir: string;
@@ -143,5 +143,67 @@ describe("detectInstallMethod", () => {
   it("returns 'binary' when the path does not exist (best-effort fallback)", () => {
     const nonexistent = join(testDir, "no-such", "ref");
     expect(detectInstallMethod(nonexistent)).toBe("binary");
+  });
+
+  it("uses execPath when argv1 is a bunfs virtual path (Bun single-file executable)", () => {
+    const binDir = join(testDir, "home", "user", ".local", "bin");
+    mkdirSync(binDir, { recursive: true });
+    const execPath = join(binDir, "ref");
+    writeFileSync(execPath, "elf binary\n");
+
+    expect(detectInstallMethod("/$bunfs/root/ref-linux-x64", execPath)).toBe("binary");
+  });
+
+  it("pattern-matches the substituted execPath, not the bunfs fall-through (dev checkout wins)", () => {
+    // If detection merely fell through to "binary" for bunfs paths, an
+    // execPath inside a git worktree would be misclassified. Asserting "dev"
+    // proves execPath drives the pattern-matching.
+    const repoDir = join(testDir, "repo");
+    mkdirSync(join(repoDir, ".git"), { recursive: true });
+    mkdirSync(join(repoDir, "bin"), { recursive: true });
+    writeFileSync(join(repoDir, "package.json"), '{"name":"reference-manager"}\n');
+    const execPath = join(repoDir, "bin", "ref");
+    writeFileSync(execPath, "elf binary\n");
+
+    expect(detectInstallMethod("/$bunfs/root/ref-linux-x64", execPath)).toBe("dev");
+  });
+
+  it("recognizes the Windows bunfs marker (B:\\~BUN\\)", () => {
+    const binDir = join(testDir, "home", "user", ".local", "bin");
+    mkdirSync(binDir, { recursive: true });
+    const execPath = join(binDir, "ref");
+    writeFileSync(execPath, "elf binary\n");
+
+    expect(detectInstallMethod("B:\\~BUN\\root\\ref.exe", execPath)).toBe("binary");
+  });
+
+  it("ignores execPath when argv1 is a regular on-disk path", () => {
+    const nmBin = join(testDir, "usr", "lib", "node_modules", "@ncukondo", "reference-manager");
+    mkdirSync(nmBin, { recursive: true });
+    const cliPath = join(nmBin, "cli.js");
+    writeFileSync(cliPath, "#!/usr/bin/env node\n");
+
+    const binDir = join(testDir, "home", "user", ".local", "bin");
+    mkdirSync(binDir, { recursive: true });
+    const execPath = join(binDir, "node");
+    writeFileSync(execPath, "node binary\n");
+
+    expect(detectInstallMethod(cliPath, execPath)).toBe("npm-global");
+  });
+});
+
+describe("isBunfsPath", () => {
+  it.each([
+    ["/$bunfs/root/ref-linux-x64", true],
+    ["/$bunfs/root/nested/dir/cli.js", true],
+    ["B:\\~BUN\\root\\ref.exe", true],
+    ["b:\\~bun\\root\\ref.exe", true],
+    ["B:/~BUN/root/ref.exe", true],
+    ["/home/user/.local/bin/ref", false],
+    ["/usr/lib/node_modules/@ncukondo/reference-manager/bin/cli.js", false],
+    ["C:\\Users\\user\\.local\\bin\\ref.exe", false],
+    ["", false],
+  ])("%s -> %s", (path, expected) => {
+    expect(isBunfsPath(path)).toBe(expected);
   });
 });

--- a/src/upgrade/detect.ts
+++ b/src/upgrade/detect.ts
@@ -3,10 +3,8 @@
  *
  * Resolves `argv1` (defaults to `process.argv[1]`) through `realpathSync` and
  * pattern-matches the resolved path to determine how the user installed `ref`.
- *
- * TODO(stage2): Wire this into `ref upgrade` (see Step 4/6 of
- * `spec/tasks/20260420-01-self-upgrade.md`). It is currently only used by
- * tests and will select the upgrade strategy once the command lands.
+ * Inside a Bun single-file executable, `argv[1]` is a bunfs virtual path, so
+ * the real on-disk binary path (`execPath`) is substituted first.
  */
 
 import { existsSync, realpathSync, statSync } from "node:fs";
@@ -73,8 +71,34 @@ function isInsideGitWorktree(startPath: string): boolean {
   }
 }
 
-export function detectInstallMethod(argv1?: string): InstallMethod {
+/**
+ * Bun single-file executables mount the bundled sources on a virtual
+ * read-only filesystem: `/$bunfs/root/...` on POSIX, `B:\~BUN\root\...`
+ * (drive letter + `~BUN` marker) on Windows. Paths there are not writable
+ * and do not correspond to the on-disk binary.
+ */
+const BUNFS_POSIX_PREFIX = "/$bunfs/";
+const BUNFS_WINDOWS_PATTERN = /^[a-z]:[\\/]~bun[\\/]/i;
+
+export function isBunfsPath(path: string): boolean {
+  return path.startsWith(BUNFS_POSIX_PREFIX) || BUNFS_WINDOWS_PATTERN.test(path);
+}
+
+/**
+ * Returns the real on-disk path of the running entrypoint: `argv1` normally,
+ * or `execPath` when `argv1` points into the bunfs virtual filesystem of a
+ * Bun single-file executable.
+ */
+export function resolveEntrypoint(argv1?: string, execPath?: string): string | undefined {
   const source = argv1 ?? process.argv[1];
+  if (source !== undefined && isBunfsPath(source)) {
+    return execPath ?? process.execPath;
+  }
+  return source;
+}
+
+export function detectInstallMethod(argv1?: string, execPath?: string): InstallMethod {
+  const source = resolveEntrypoint(argv1, execPath);
   if (!source) return "binary";
 
   const resolved = safeRealpath(source);


### PR DESCRIPTION
## Summary

Fixes the two bugs that prevented `ref upgrade` from actually upgrading an installed single-binary `ref` (task `spec/tasks/20260712-01-fix-upgrade-cache-and-bunfs.md`):

1. **Stale-cache bug** — `ref upgrade` reused the 24h update-notifier cache (`{data}/update-check.json`), so it reported `Already up to date (0.34.0)` even after v0.35.0 was released. `upgradeBinary` and `upgradeNpmGlobal` now resolve the target with `getLatest({ force: true })`; the passive startup notifier remains cache-first.
2. **bunfs destPath bug** — inside a Bun single-file executable, `process.argv[1]` is a virtual read-only path (`/$bunfs/root/...`), so the upgrade tried to write `/$bunfs/root/ref-linux-x64.tmp.<pid>` and failed with `ENOENT`. New `isBunfsPath` / `resolveEntrypoint` helpers in `src/upgrade/detect.ts` substitute `process.execPath` (injectable for tests) before realpath/pattern-matching, wired into both `detectInstallMethod` and `resolveDestPath`. Windows bunfs marker (`B:\~BUN\...`) is handled too. Non-bunfs behavior is unchanged.

Also updates `spec/features/self-upgrade.md` with both clarified behaviors.

## Original reproduced failures (0.34.0 installed at `~/.local/bin/ref`, v0.35.0 released)

```
$ ref upgrade
Already up to date (0.34.0)          # stale cache reused

$ rm {data}/update-check.json && ref upgrade
Error: Failed to write downloaded binary: ENOENT: no such file or directory,
open '/$bunfs/root/ref-linux-x64.tmp.<pid>'
```

## Manual verification (local `bun build --compile` smoke test)

Built `dist/ref-linux-x64` from this branch, installed it to a sandbox `…/.local/bin/ref` with `XDG_DATA_HOME` pointing at a sandbox data dir:

1. **Cache bypass**: seeded a *fresh* cache claiming `latest: 0.0.1`, then ran `ref upgrade --check` → reported `Already up to date (0.35.0)` (live API result, not the cached 0.0.1) and refreshed the cache file to 0.35.0.
2. **bunfs destPath**: ran `ref upgrade --version v0.34.0` from the compiled (bunfs) binary → `Upgraded ref 0.35.0 -> 0.34.0`, and the on-disk binary at `…/.local/bin/ref` afterwards reports `0.34.0`. This is the exact download→verify→atomic-replace path that previously died on the `/$bunfs/` tmp path.

## Tests

- `npm run test:unit -- upgrade detect` — 313 tests pass (new: force-cache-bypass assertions in `apply-binary`/`apply-npm`, bunfs detection/destPath cases in `detect`/`upgrade` incl. Windows marker and a not-by-fall-through case).
- `npm run lint` / `npm run typecheck` — clean.
- Note: full `npm run test:unit` has 9 failures in unrelated files (`config/loader`, `fulltext`, `search`, `file-watcher`, `mcp/add`); verified pre-existing on this machine without these changes (fail identically with the work stashed) — environment-dependent, untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZRQ36cntjXsPkjA9cBhLZ