### PR TITLE
fix(export): emit keyword as CSL-JSON string, not array (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Export keyword normalization (#106)**: `ref export -o json` / `-o yaml` no longer emit `keyword` as a JSON array (which is invalid CSL-JSON and breaks pandoc/citeproc on the whole bibliography). Export output now applies the same array→`"; "`-string normalization as the storage serializer.
+  - Extracted reusable `toSerializableCslItem` / `toSerializableCslLibrary` helpers from `serializeCslJson` (`src/core/csl-json/serializer.ts`) and applied them in `formatExportOutput` (`src/cli/commands/export.ts`) for both JSON and YAML, covering single-object and array output. BibTeX output is unaffected (it does not emit `keyword`).
 - **Server Mutation Persistence (#93)**: Mutations made via the HTTP server now survive restart.
   - `POST /api/references/` now persists via a new `addReference` helper (`src/features/operations/add-reference.ts`) that bundles `library.add()` with `library.save()`, matching the PUT/DELETE helpers so future mutation routes cannot forget to persist.
   - Server shutdown (`SIGINT`/`SIGTERM`) flushes the in-memory library to disk before closing the file watcher. If the shutdown flush itself fails, `dispose()` sets `process.exitCode = 1` (rather than throwing) so the CLI exits non-zero while watcher cleanup still runs. The cleanup handler no longer writes `exitCode = 0` at its tail, so the failure code set by `dispose()` survives to process exit (PR #94 review2 #1).

--- a/spec/tasks/20260724-01-fix-export-keyword-array.md
+++ b/spec/tasks/20260724-01-fix-export-keyword-array.md
@@ -1,0 +1,80 @@
+# Task: Fix `ref export` json/yaml emits `keyword` as array (invalid CSL-JSON)
+
+## Purpose
+
+`ref export -o json` can emit `keyword` as a JSON **array**, which is invalid
+CSL-JSON (the spec expects a `"; "`-separated string). Passing such an export to
+pandoc/citeproc fails the whole file. Apply the same keyword normalization used
+by the storage serializer to the export json/yaml output so `ref export` always
+produces spec-compliant CSL-JSON.
+
+Fixes #106.
+
+## Root Cause
+
+- In-memory `keyword` is typed as `z.array(z.string())` (`src/core/csl-json/types.ts:91`).
+- Storage write path normalizes array → `"; "` string via
+  `serializeCslJson` (`src/core/csl-json/serializer.ts`).
+- Read path reverses string → array via `parseKeyword` (`src/core/csl-json/parser.ts`).
+- `formatExportOutput` calls `JSON.stringify` directly on raw in-memory items
+  (`src/cli/commands/export.ts:102`), bypassing normalization → array leaks out.
+- The normalization logic (`serializeKeyword` + item mapping) is currently
+  private inside `serializer.ts`, so export cannot reuse it.
+
+## References
+
+- Spec: `spec/guidelines/pandoc.md`, `spec/core/data-model.md`
+- Related: `src/core/csl-json/serializer.ts`, `src/cli/commands/export.ts`
+- Issue: #106
+
+## TDD Workflow
+
+For each step, follow the Red-Green-Refactor cycle (see `spec/guidelines/testing.md`).
+
+## Steps
+
+### Step 1: Extract reusable keyword normalization in serializer
+
+- [ ] Write test: `src/core/csl-json/serializer.test.ts` (add cases for the new
+      `toSerializableCslItem` / `toSerializableCslLibrary` helpers: keyword array
+      → `"; "` string; empty/undefined keyword → field omitted; other fields
+      preserved)
+- [ ] Implement: export `toSerializableCslItem(item)` and
+      `toSerializableCslLibrary(library)` from `serializer.ts`; refactor
+      `serializeCslJson` to use them (behavior unchanged)
+- [ ] Verify Green: `npm run test:unit -- serializer.test.ts`
+- [ ] Lint/Type check: `npm run lint && npm run typecheck`
+
+### Step 2: Apply normalization in export json/yaml output
+
+- [ ] Write test: `src/cli/commands/export.test.ts` (keyword array →
+      `-o json` emits `"; "` string, not array; `-o yaml` same; single-ID
+      object output normalized; keyword-less item omits field)
+- [ ] Implement: in `formatExportOutput`, normalize items via the serializer
+      helpers before `JSON.stringify` (json) and `yamlStringify` (yaml);
+      handle both single-object and array output shapes; bibtex path unchanged
+- [ ] Verify Green: `npm run test:unit -- export.test.ts`
+- [ ] Lint/Type check: `npm run lint && npm run typecheck`
+
+## Out of Scope
+
+- BibTeX export (`bibtex.ts` does not emit `keyword`)
+- Changing the in-memory `keyword` type (arrays remain in memory; normalization
+  happens only at output boundaries, consistent with existing design)
+
+## Manual Verification
+
+Non-TTY tests (automated):
+- [ ] Add an item with multiple tags, `ref export <id> -o json` → `keyword` is a
+      `"; "`-separated string
+- [ ] `ref export --all -o json` piped to `jq` — no `keyword` arrays present
+
+## Completion Checklist
+
+- [ ] All tests pass (`npm run test`)
+- [ ] Lint passes (`npm run lint`)
+- [ ] Type check passes (`npm run typecheck`)
+- [ ] Build succeeds (`npm run build`)
+- [ ] CHANGELOG.md updated
+- [ ] Close linked issue (include `Closes #106` in PR description)
+- [ ] Move this file to `spec/tasks/completed/`

--- a/src/cli/commands/export.test.ts
+++ b/src/cli/commands/export.test.ts
@@ -364,6 +364,60 @@ describe("export command", () => {
       expect(output).toContain("- id: jones-2023");
     });
 
+    describe("keyword normalization (CSL-JSON compliance)", () => {
+      const itemWithKeywords: CslItem = {
+        id: "kw-2024",
+        type: "article-journal",
+        title: "Keyworded Article",
+        keyword: ["machine learning", "deep learning", "neural networks"],
+        custom: { uuid: "uuid-kw" },
+      };
+
+      it("should emit keyword as semicolon-separated string in JSON (not array)", () => {
+        const result: ExportCommandResult = { items: [itemWithKeywords], notFound: [] };
+        const options: ExportCommandOptions = { all: true, output: "json" };
+
+        const parsed = JSON.parse(formatExportOutput(result, options));
+
+        expect(Array.isArray(parsed[0].keyword)).toBe(false);
+        expect(parsed[0].keyword).toBe("machine learning; deep learning; neural networks");
+      });
+
+      it("should emit keyword as string for single-item object JSON output", () => {
+        const result: ExportCommandResult = { items: [itemWithKeywords], notFound: [] };
+        const options: ExportCommandOptions = { ids: ["kw-2024"], output: "json" };
+
+        const parsed = JSON.parse(formatExportOutput(result, options));
+
+        expect(Array.isArray(parsed)).toBe(false);
+        expect(parsed.keyword).toBe("machine learning; deep learning; neural networks");
+      });
+
+      it("should omit keyword field when empty in JSON output", () => {
+        const item: CslItem = {
+          id: "empty-kw",
+          type: "article-journal",
+          keyword: [],
+          custom: { uuid: "uuid-empty" },
+        };
+        const result: ExportCommandResult = { items: [item], notFound: [] };
+        const options: ExportCommandOptions = { all: true, output: "json" };
+
+        const parsed = JSON.parse(formatExportOutput(result, options));
+
+        expect(parsed[0]).not.toHaveProperty("keyword");
+      });
+
+      it("should emit keyword as string in YAML output", () => {
+        const result: ExportCommandResult = { items: [itemWithKeywords], notFound: [] };
+        const options: ExportCommandOptions = { all: true, output: "yaml" };
+
+        const output = formatExportOutput(result, options);
+
+        expect(output).toContain("keyword: machine learning; deep learning; neural networks");
+      });
+    });
+
     it("should output as BibTeX with --format bibtex", () => {
       const result: ExportCommandResult = {
         items: [mockItem],

--- a/src/cli/commands/export.ts
+++ b/src/cli/commands/export.ts
@@ -5,6 +5,7 @@
  */
 
 import { stringify as yamlStringify } from "yaml";
+import { toSerializableCslItem, toSerializableCslLibrary } from "../../core/csl-json/serializer.js";
 import type { CslItem } from "../../core/csl-json/types.js";
 import { formatBibtex } from "../../features/format/bibtex.js";
 import type { ExecutionContext } from "../execution-context.js";
@@ -94,22 +95,26 @@ export function formatExportOutput(
 ): string {
   const format = options.output ?? "json";
 
+  // BibTeX handles its own field mapping and does not emit keyword.
+  if (format === "bibtex") {
+    return formatBibtex(result.items);
+  }
+
   // Determine if this is a single ID request (output object vs array)
   const singleIdRequest = (options.ids?.length ?? 0) === 1 && !options.all && !options.search;
-  const data = result.items.length === 1 && singleIdRequest ? result.items[0] : result.items;
+  const singleItem = result.items.length === 1 && singleIdRequest ? result.items[0] : undefined;
 
-  if (format === "json") {
-    return JSON.stringify(data, null, 2);
-  }
+  // Normalize items to spec-compliant CSL-JSON (keyword array -> "; " string)
+  // before emitting JSON/YAML, mirroring the storage serializer.
+  const data: unknown = singleItem
+    ? toSerializableCslItem(singleItem)
+    : toSerializableCslLibrary(result.items);
 
   if (format === "yaml") {
     return yamlStringify(data);
   }
 
-  if (format === "bibtex") {
-    return formatBibtex(result.items);
-  }
-
+  // Default to JSON (covers format === "json" and any unknown value).
   return JSON.stringify(data, null, 2);
 }
 

--- a/src/core/csl-json/serializer.test.ts
+++ b/src/core/csl-json/serializer.test.ts
@@ -2,8 +2,13 @@ import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { parseCslJson } from "./parser";
-import { serializeCslJson, writeCslJson } from "./serializer";
-import type { CslLibrary } from "./types";
+import {
+  serializeCslJson,
+  toSerializableCslItem,
+  toSerializableCslLibrary,
+  writeCslJson,
+} from "./serializer";
+import type { CslItem, CslLibrary } from "./types";
 
 const FIXTURES_DIR = resolve(__dirname, "../../../tests/fixtures");
 const TMP_DIR = resolve(__dirname, "../../../tests/tmp");
@@ -185,6 +190,77 @@ describe("CSL-JSON Serializer", () => {
         expect(parsed[0].keyword).toBe("keyword1; keyword2; keyword3");
         expect(parsed[0].keyword).toContain("; ");
       });
+    });
+  });
+
+  describe("toSerializableCslItem", () => {
+    it("should normalize keyword array to semicolon-separated string", () => {
+      const item: CslItem = {
+        id: "test",
+        type: "article-journal",
+        keyword: ["machine learning", "deep learning"],
+      };
+
+      const result = toSerializableCslItem(item);
+
+      expect(result.keyword).toBe("machine learning; deep learning");
+    });
+
+    it("should omit keyword field when empty", () => {
+      const item: CslItem = {
+        id: "test",
+        type: "article-journal",
+        keyword: [],
+      };
+
+      const result = toSerializableCslItem(item);
+
+      expect(result).not.toHaveProperty("keyword");
+    });
+
+    it("should omit keyword field when undefined", () => {
+      const item: CslItem = {
+        id: "test",
+        type: "article-journal",
+      };
+
+      const result = toSerializableCslItem(item);
+
+      expect(result).not.toHaveProperty("keyword");
+    });
+
+    it("should preserve other fields", () => {
+      const item: CslItem = {
+        id: "test",
+        type: "article-journal",
+        title: "A Title",
+        keyword: ["one", "two"],
+        custom: {
+          uuid: "550e8400-e29b-41d4-a716-446655440000",
+          timestamp: "2024-01-01T00:00:00.000Z",
+        },
+      };
+
+      const result = toSerializableCslItem(item);
+
+      expect(result.id).toBe("test");
+      expect(result.type).toBe("article-journal");
+      expect(result.title).toBe("A Title");
+      expect(result.custom).toEqual(item.custom);
+    });
+  });
+
+  describe("toSerializableCslLibrary", () => {
+    it("should normalize keyword for every item", () => {
+      const library: CslLibrary = [
+        { id: "a", type: "article-journal", keyword: ["x", "y"] },
+        { id: "b", type: "article-journal" },
+      ];
+
+      const result = toSerializableCslLibrary(library);
+
+      expect(result[0].keyword).toBe("x; y");
+      expect(result[1]).not.toHaveProperty("keyword");
     });
   });
 

--- a/src/core/csl-json/serializer.ts
+++ b/src/core/csl-json/serializer.ts
@@ -1,5 +1,5 @@
 import { writeFileAtomic } from "../../utils/file.js";
-import type { CslLibrary } from "./types";
+import type { CslItem, CslLibrary } from "./types";
 
 /**
  * Convert keyword array to semicolon-separated string
@@ -15,27 +15,46 @@ function serializeKeyword(keywords: string[] | undefined): string | undefined {
 }
 
 /**
+ * Convert a CSL item to its spec-compliant serializable form.
+ *
+ * The in-memory `keyword` field is an array, but CSL-JSON expects a
+ * semicolon-separated string. This normalizes `keyword` and omits the field
+ * when it is empty or undefined. Use this at any output boundary (storage
+ * write, `export` command) so emitted CSL-JSON is always valid.
+ *
+ * @param item - CSL item with in-memory (array) keyword
+ * @returns Item with `keyword` normalized to a string (or omitted)
+ */
+export function toSerializableCslItem(item: CslItem): Record<string, unknown> {
+  const { keyword, ...rest } = item;
+  const serializedKeyword = serializeKeyword(keyword);
+
+  if (serializedKeyword === undefined) {
+    return rest;
+  }
+
+  return {
+    ...rest,
+    keyword: serializedKeyword,
+  };
+}
+
+/**
+ * Convert a CSL library to its spec-compliant serializable form.
+ * @param library - CSL-JSON library (array of items)
+ * @returns Array of items with normalized keyword fields
+ */
+export function toSerializableCslLibrary(library: CslLibrary): Record<string, unknown>[] {
+  return library.map(toSerializableCslItem);
+}
+
+/**
  * Serialize a CSL-JSON library to a formatted JSON string
  * @param library - CSL-JSON library (array of items)
  * @returns Formatted JSON string with 2-space indentation
  */
 export function serializeCslJson(library: CslLibrary): string {
-  // Convert keyword arrays to semicolon-separated strings
-  const libraryForJson = library.map((item) => {
-    const { keyword, ...rest } = item;
-    const serializedKeyword = serializeKeyword(keyword);
-
-    if (serializedKeyword === undefined) {
-      return rest;
-    }
-
-    return {
-      ...rest,
-      keyword: serializedKeyword,
-    };
-  });
-
-  return JSON.stringify(libraryForJson, null, 2);
+  return JSON.stringify(toSerializableCslLibrary(library), null, 2);
 }
 
 /**


### PR DESCRIPTION
## Summary

`ref export -o json` (and `-o yaml`) could emit `keyword` as a JSON **array**, which is invalid CSL-JSON — the spec expects a semicolon-separated string. Passing such an export to pandoc/citeproc fails the **entire** bibliography if even one entry has an array keyword (reporter hit 1 of 5986 entries).

## Root cause

- In-memory `keyword` is `z.array(z.string())` (`src/core/csl-json/types.ts`).
- The storage serializer normalizes array → `"; "` string (`serializeCslJson`), and the parser reverses it on read.
- `formatExportOutput` bypassed the serializer and called `JSON.stringify` directly on raw in-memory items, leaking the array into the export.

## Changes

- Extract reusable `toSerializableCslItem` / `toSerializableCslLibrary` helpers from `serializeCslJson` (`src/core/csl-json/serializer.ts`). `serializeCslJson` now delegates to them — behavior unchanged.
- Apply the helpers in `formatExportOutput` (`src/cli/commands/export.ts`) for both JSON and YAML, covering single-object and array output shapes.
- BibTeX output is unchanged (it does not emit `keyword`).
- CHANGELOG updated.

## Tests

- `serializer.test.ts`: new cases for the extracted helpers (array → string, empty/undefined omitted, other fields preserved).
- `export.test.ts`: new cases — JSON array output emits string; single-item object output emits string; empty keyword omitted; YAML emits string.
- Full suite green except 5 pre-existing `config/loader.test.ts` failures unrelated to this change (environment auto-detects an installed Chrome for `browserPath` default; fail identically on `main`).

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)