### PR TITLE
feat(superseded): custom.superseded_by pointers and ref deprecate (#108, PR-1 of 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Superseded references** (#108): `ref deprecate <id> --to <id>` records that a reference
+  should no longer be cited and where to cite instead, without deleting it — deleting would
+  leave an unresolvable key in any manuscript that already cites it
+  - New reserved fields `custom.superseded_by` / `superseded_reason` / `superseded_at`.
+    `superseded_by` holds the successor's **UUID**, not its citation key, so the pointer
+    survives the key renames that collision resolution performs
+  - `ref deprecate` is the only writer: the three fields joined `MANAGED_CUSTOM_FIELDS`, so
+    `update --set custom.superseded_*` is rejected and `edit` restores the originals. That is
+    what keeps the successor-exists, self-reference and cycle checks meaningful
+  - Options: `--to <id>`, `--unset`, `--reason duplicate|published_version|other`, `--uuid`,
+    `-o json`, `--full`
+  - Read commands report on **stderr** only — stdout stays byte-identical, so existing
+    pipelines are unaffected:
+    - `show` warns and adds a `SUPERSEDED by` line to pretty output
+    - `cite` and `search` warn without filtering
+    - `list` hides superseded records; `--include-superseded` restores them
+    - `export` keeps the record and adds a summary line naming how many were included
+  - Chains are followed to the final successor; a cycle introduced by hand-editing
+    `library.json` is reported rather than looped over
+  - This is the first of three parts of #108. Still to come: `ref duplicates` for a
+    retroactive DOI/PMID/ISBN/arXiv/ERIC scan, and a `check --fix` action that adds the
+    published version as a new record and marks the old one
+
 ### Fixed
 
 - **Self-Upgrade hardening** (#101):

--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ ref list --format bibtex
 ref list --sort published --order desc          # Latest first
 ref list --sort author --limit 10               # First 10 by author
 ref list --sort created -n 20 --offset 20       # Page 2 (items 21-40)
+ref list --include-superseded                   # Also show deprecated records
 
 # Search references
 ref search "machine learning"
@@ -520,6 +521,49 @@ Sources queried:
 Use `--fix` to interactively update changed fields from the remote source.
 
 Results are saved to `custom.check` by default for skip-if-recent logic.
+
+### Superseded References
+
+When two records point at the same work — an import duplicate, a preprint kept alongside its
+published version, a conference paper and its journal article — mark the redundant one instead of
+deleting it. Deleting would break any manuscript that already cites the old key.
+
+```bash
+# Cite Carless2023-yt instead of Carless2020-yj
+ref deprecate Carless2020-yj --to Carless2023-yt --reason duplicate
+
+# Reasons: duplicate | published_version | other (default: other)
+ref deprecate preprint-2024 --to published-2025 --reason published_version
+
+# Clear the mark
+ref deprecate Carless2020-yj --unset
+
+# JSON output
+ref deprecate Carless2020-yj --to Carless2023-yt -o json
+```
+
+The mark is stored under `custom.superseded_by` as the successor's UUID, so it survives citation
+key renames. `ref deprecate` is the only writer — `update --set` and `edit` cannot touch these
+fields, which is what keeps the successor-exists and cycle checks meaningful.
+
+Read commands report a superseded record on **stderr**, never stdout, so pipelines are unaffected:
+
+```
+$ ref export --all -o json > refs.json
+[SUPERSEDED] Carless2020-yj -> Carless2023-yt (duplicate)
+1 superseded reference included. Update your manuscript keys.
+```
+
+| Command | Behavior |
+|---------|----------|
+| `show` | Warns; pretty output also shows a `SUPERSEDED by` line |
+| `cite` | Warns per cited record |
+| `search` | Warns; results are not filtered |
+| `list` | Hides superseded records; `--include-superseded` shows them |
+| `export` | Keeps the record in the output and warns |
+
+`export` deliberately keeps superseded records: dropping one would leave an unresolvable citation
+key in any manuscript still citing it, turning a warning into a failed bibliography build.
 
 ### Edit Command
 

--- a/spec/_index.md
+++ b/spec/_index.md
@@ -49,6 +49,7 @@ spec/
 │   ├── pagination.md            # Sorting, limit, offset for list/search
 │   ├── shell-completion.md      # Bash/Zsh/Fish auto-completion
 │   ├── duplicate-detection.md   # Duplicate detection rules
+│   ├── superseded.md            # Superseded pointers, deprecate command
 │   ├── file-monitoring.md       # File watching, reload
 │   ├── write-safety.md          # Atomic write, backup, merge
 │   ├── metadata.md              # Standard and custom fields
@@ -106,6 +107,7 @@ spec/
 | `server` | `architecture/http-server.md` |
 | `mcp` | `architecture/mcp-server.md` |
 | `check` | `features/check.md` |
+| `deprecate` | `features/superseded.md` |
 | `completion` | `features/shell-completion.md` |
 
 ### Core Concepts
@@ -116,6 +118,7 @@ spec/
 | ID generation | `core/data-model.md` |
 | Full-text files | `features/fulltext.md` |
 | Duplicate detection | `features/duplicate-detection.md` |
+| Superseded references | `features/superseded.md` |
 | Conflict resolution | `features/write-safety.md` |
 | File watching | `features/file-monitoring.md` |
 | JSON output (add/remove/update) | `features/json-output.md` |

--- a/spec/core/data-model.md
+++ b/spec/core/data-model.md
@@ -48,6 +48,9 @@ The `custom` field stores reference-manager-specific metadata:
   "timestamp": "2024-01-02T10:30:00.000Z",
   "additional_urls": ["https://example.com/resource"],
   "tags": ["review", "important"],
+  "superseded_by": "<uuid of successor>",
+  "superseded_reason": "duplicate",
+  "superseded_at": "2026-08-07T00:00:00.000Z",
   "attachments": {
     "directory": "Smith-2024-PMID12345678-<uuid-prefix>",
     "files": [
@@ -66,6 +69,9 @@ The `custom` field stores reference-manager-specific metadata:
 | `timestamp` | Last modification time (for LWW conflict resolution) |
 | `additional_urls` | Optional array of additional URLs |
 | `tags` | User-defined tags for categorization (see `features/metadata.md`) |
+| `superseded_by` | uuid of the reference to cite instead (see `features/superseded.md`) |
+| `superseded_reason` | `duplicate` \| `published_version` \| `other` |
+| `superseded_at` | When the mark was set |
 | `attachments` | Attached files (see `features/attachments.md`) |
 | `attachments.directory` | Per-reference directory name |
 | `attachments.files` | Array of attached file metadata |

--- a/spec/features/superseded.md
+++ b/spec/features/superseded.md
@@ -1,0 +1,138 @@
+# Superseded References
+
+## Purpose
+
+Record that a reference should no longer be cited, and where to cite instead.
+
+Three situations produce a redundant record that the library cannot currently express (#108):
+
+| Case | Origin | Detectable |
+|------|--------|------------|
+| Import duplicate | Same work imported twice from Paperpile/Zotero, matching DOI/PMID/ISBN/arXiv/ERIC | Yes — `ref duplicates` |
+| Preprint → published | Both versions kept as separate records | Yes — `ref check` (`version_changed`) |
+| Conference → journal | Different DOIs, no Crossref update relation | No — manual only |
+
+Deleting the redundant record is not an option: a manuscript that already cites the old key would
+stop resolving. The record stays, marked, with a pointer to its successor.
+
+## Data Model
+
+Three reserved fields under `custom`:
+
+```jsonc
+"custom": {
+  "superseded_by": "018f2c9a-...-a91b",           // uuid of the successor
+  "superseded_reason": "duplicate",               // duplicate | published_version | other
+  "superseded_at": "2026-08-07T00:00:00.000Z"     // ISO 8601, when the mark was set
+}
+```
+
+**`superseded_by` holds the successor's uuid, not its citation key.** Citation keys are mutable —
+`edit` and `update` rename on collision (`src/core/library.ts`, `resolveNewId`) — so a key-valued
+pointer would dangle silently. Output always resolves the uuid back to a citation key for display;
+the uuid never appears in user-facing text.
+
+The fields live under `custom`, so `export` output stays valid CSL-JSON and citeproc ignores them.
+
+### Write access
+
+All three are members of `MANAGED_CUSTOM_FIELDS`: hidden from `edit`, preserved from the original on
+edit merge, and rejected by `update --set` (`Cannot set protected field`). `ref deprecate` is the
+only writer, so the existence check and cycle check cannot be bypassed by hand-editing.
+
+They are *not* members of `PROTECTED_CUSTOM_FIELDS`, so marking a reference counts as a real change
+for change detection and bumps `custom.timestamp`.
+
+### Invariants
+
+- The three fields are set and cleared together; a record never carries a partial mark
+- `superseded_by` never points at the record's own uuid
+- Following `superseded_by` from a record never returns to that record (no cycles)
+- `superseded_by` may point at a record that is itself superseded (chains are allowed); consumers
+  resolve to the end of the chain
+
+A pointer whose uuid is absent from the library is **dangling**. This is reachable — the successor
+can be removed later — and is reported, not repaired automatically.
+
+## Command: `deprecate`
+
+```
+ref deprecate <old-id> --to <new-id> [--reason <reason>] [--uuid] [-o json]
+ref deprecate <old-id> --unset [--uuid] [-o json]
+```
+
+| Option | Meaning |
+|--------|---------|
+| `--to <new-id>` | Citation key (or uuid with `--uuid`) of the successor |
+| `--unset` | Clear the mark |
+| `--reason` | `duplicate` \| `published_version` \| `other` (default: `other`) |
+| `--uuid` | Interpret both identifiers as uuids |
+
+`--to` and `--unset` are mutually exclusive; exactly one is required.
+
+### Validation
+
+| Condition | Exit code |
+|-----------|-----------|
+| `<old-id>` not found | `NOT_FOUND` |
+| `--to` target not found | `NOT_FOUND` |
+| `--to` resolves to `<old-id>` itself | `VALIDATION_ERROR` |
+| Successor chain from `--to` reaches `<old-id>` | `VALIDATION_ERROR` |
+| Neither or both of `--to` / `--unset` | `VALIDATION_ERROR` |
+| `--unset` on a record with no mark | success, reported as a no-op |
+
+Re-running `deprecate` on an already-marked record overwrites the mark and refreshes
+`superseded_at`.
+
+## Reference-Time Reporting
+
+A superseded record surfaced by any read command produces one stderr line per record. **stdout is
+never touched** — piping `ref export`, `ref cite`, or `ref list --output ids` into another tool
+keeps working byte-for-byte.
+
+```
+[SUPERSEDED] Carless2020-yj -> Carless2023-yt (duplicate)
+```
+
+Dangling and self-terminating cases:
+
+```
+[SUPERSEDED] Carless2020-yj -> <missing: 018f2c9a-...> (duplicate)
+```
+
+| Command | Behavior |
+|---------|----------|
+| `show` | Warn; pretty output also renders a `Superseded by` line |
+| `cite` | Warn per cited record |
+| `search` | Warn per matching record; results are **not** filtered |
+| `list` | Superseded records are **hidden**; `--include-superseded` shows them (and warns) |
+| `export` | Records are **included**; warn per record plus a summary line |
+
+### Why `list` hides but `export` does not
+
+`list` is a browsing command — a superseded record is noise once its successor exists.
+
+`export` feeds bibliography builds (`ref export --all` → citeproc). Dropping a record there would
+break any manuscript still citing the old key, turning a warning into a build failure. The record
+stays in the output; the warning tells the author which keys to update:
+
+```
+[SUPERSEDED] Carless2020-yj -> Carless2023-yt (duplicate)
+1 superseded reference included. Update your manuscript keys.
+```
+
+`search` is an explicit query — silently dropping a record the user asked for by name would be
+surprising, so it warns only.
+
+## Non-Goals
+
+- No automatic rewriting of citation keys in manuscripts
+- No automatic removal of superseded records
+- No repair of dangling pointers (reported only)
+
+## See Also
+
+- `src/features/superseded/` — resolution, validation, warning formatting
+- `src/cli/commands/deprecate.ts` — command implementation
+- `spec/features/duplicate-detection.md` — the matching rules `ref duplicates` reuses
+- `spec/features/check.md` — `version_changed` findings

--- a/spec/tasks/20260807-02-superseded-pointers.md
+++ b/spec/tasks/20260807-02-superseded-pointers.md
@@ -42,83 +42,90 @@ For each step, follow the Red-Green-Refactor cycle (see `spec/guidelines/testing
 
 ### Step 1: Schema and field protection
 
-- [ ] Write test: `src/core/csl-json/types.test.ts` — `superseded_by` / `superseded_reason` /
+- [x] Write test: `src/core/csl-json/types.test.ts` — `superseded_by` / `superseded_reason` /
       `superseded_at` parse, reason is a union, partial marks still parse (other software writes
       `custom` freely)
-- [ ] Add the three fields to `CslCustomSchema` (`src/core/csl-json/types.ts`)
-- [ ] Add them to `MANAGED_CUSTOM_FIELDS` (`src/core/library-interface.ts`)
-- [ ] Write test: `src/cli/commands/update.test.ts` — `update --set custom.superseded_by=x` is
+- [x] Add the three fields to `CslCustomSchema` (`src/core/csl-json/types.ts`)
+- [x] Add them to `MANAGED_CUSTOM_FIELDS` (`src/core/library-interface.ts`)
+- [x] Write test: `src/cli/commands/update.test.ts` — `update --set custom.superseded_by=x` is
       rejected as a protected field
-- [ ] Write test: `src/cli/commands/edit.test.ts` — an edit that drops or rewrites the fields keeps
-      the original values
-- [ ] Verify Green + `npm run lint && npm run typecheck`
+- [x] Write test: `src/features/edit/yaml-serializer.test.ts` — the mark is not exposed for
+      editing (the merge that restores managed fields is already covered by existing edit tests)
+- [x] Verify Green + `npm run lint && npm run typecheck`
 
 ### Step 2: Resolution module (`src/features/superseded/`)
 
-- [ ] Write test: `src/features/superseded/resolver.test.ts`
+- [x] Write test: `src/features/superseded/resolver.test.ts`
   - `getSupersededMark(item)` → mark or null; partial marks treated as absent
   - `resolveSuccessor(item, allItems)` → `{ target, dangling }`
   - `resolveFinalSuccessor(item, allItems)` → end of chain, terminates on a cycle rather than
     looping forever (defensive: `deprecate` prevents cycles, hand-edited files may not)
   - `isSuperseded(item)`
-- [ ] Create stub, verify Red, implement, verify Green
-- [ ] Write test: `src/features/superseded/warning.test.ts` — `formatSupersededWarning` for the
+- [x] Create stub, verify Red, implement, verify Green
+- [x] Write test: `src/features/superseded/warning.test.ts` — `formatSupersededWarning` for the
       resolved, dangling, and chained cases
-- [ ] Implement, verify Green
-- [ ] Lint/Type check
+- [x] Implement, verify Green
+- [x] Lint/Type check
 
 ### Step 3: `ref deprecate` command
 
-- [ ] Write test: `src/features/operations/deprecate.test.ts` — operation layer: set, unset,
+- [x] Write test: `src/features/operations/deprecate.test.ts` — operation layer: set, unset,
       overwrite existing mark, self-reference rejected, cycle rejected, unknown old id, unknown
       target, unset on unmarked record is a no-op
-- [ ] Create stub `src/features/operations/deprecate.ts`, verify Red, implement, verify Green
-- [ ] Write test: `src/cli/commands/deprecate.test.ts` — option parsing (`--to` / `--unset` mutual
+- [x] Create stub `src/features/operations/deprecate.ts`, verify Red, implement, verify Green
+- [x] Write test: `src/cli/commands/deprecate.test.ts` — option parsing (`--to` / `--unset` mutual
       exclusion, `--reason` default `other`, `--uuid`), exit codes, text and `-o json` output
-- [ ] Implement `src/cli/commands/deprecate.ts`, register in `src/cli/index.ts`
-- [ ] Verify Green + lint/typecheck
+- [x] Implement `src/cli/commands/deprecate.ts`, register in `src/cli/index.ts`
+- [x] Verify Green + lint/typecheck
 
 ### Step 4: Reference-time warnings
 
-- [ ] Write test: `src/cli/commands/show.test.ts` — stderr warning; pretty output has a
-      `Superseded by` line; stdout unchanged in json mode
-- [ ] Write test: `src/cli/commands/cite.test.ts` — one warning per cited superseded record
-- [ ] Write test: `src/cli/commands/search.test.ts` — warns, does not filter
-- [ ] Write test: `src/cli/commands/export.test.ts` — includes the record, warns per record, prints
-      the summary line, stdout byte-identical to the unmarked case
-- [ ] Implement the warning emission in each command
-- [ ] Verify Green + lint/typecheck
+Emission is one shared helper (`src/cli/superseded-report.ts`) called by every read command, so
+the unit tests cover the helper once rather than re-testing the same branch through five command
+handlers. The per-command wiring — which handler calls it, with which items, and whether stdout
+stays clean — is covered end to end by `test-fixtures/test-superseded.sh`.
+
+- [x] Write test: `src/cli/superseded-report.test.ts` — one line per record, resolution against the
+      whole library, summary line, never writes to stdout, silent mode, and no library fetch when
+      nothing is marked
+- [x] Write test: `src/features/format/show-normalizer.test.ts` — uuid resolved back to a citation
+      key, dangling pointer, chain, cycle, null without a library
+- [x] Write test: `src/features/format/show-pretty.test.ts` — `SUPERSEDED by` line directly under
+      the header, dangling and cycle wording
+- [x] Implement the warning emission in `show`, `cite`, `search`, and `export`
+- [x] Verify Green + lint/typecheck
 
 ### Step 5: `list` filtering
 
-- [ ] Write test: `src/features/operations/list.test.ts` — superseded excluded by default,
+- [x] Write test: `src/features/operations/list.test.ts` — superseded excluded by default,
       `includeSuperseded` restores them, `total` reflects the filter
-- [ ] Implement `includeSuperseded` in `listReferences`
-- [ ] Write test: `src/cli/commands/list.test.ts` — `--include-superseded` flag, warning emitted
-      only when they are shown
-- [ ] Implement flag in `src/cli/index.ts` / `src/cli/commands/list.ts`
-- [ ] Verify Green + lint/typecheck
+- [x] Implement `includeSuperseded` in `listReferences`
+- [x] Implement flag in `src/cli/index.ts` / `src/cli/commands/list.ts`, and forward
+      `includeSuperseded` through `ILibraryOperations.list` → `ServerClient` → the `/api/list`
+      request schema, so the flag is not silently dropped in server mode
+- [x] Flag behavior covered end to end by `test-fixtures/test-superseded.sh`
+- [x] Verify Green + lint/typecheck
 
 ### Step 6: Shell completion and docs
 
-- [ ] Add `deprecate` to shell completion (`src/features/install` / completion source — check where
+- [x] Add `deprecate` to shell completion (`src/features/install` / completion source — check where
       commands are enumerated)
-- [ ] Update `spec/_index.md` command table with `deprecate` → `spec/features/superseded.md`
-- [ ] Update `spec/core/data-model.md` with the three reserved fields
-- [ ] Update README if it lists commands
+- [x] Update `spec/_index.md` command table with `deprecate` → `spec/features/superseded.md`
+- [x] Update `spec/core/data-model.md` with the three reserved fields
+- [x] Update README if it lists commands
 
 ## Manual Verification
 
 **Script**: `test-fixtures/test-superseded.sh`
 
 Non-TTY tests (automated):
-- [ ] `ref deprecate A --to B --reason duplicate` marks A; `ref show A` reports the successor
-- [ ] `ref export --all` includes A on stdout and warns on stderr; `ref export --all 2>/dev/null`
+- [x] `ref deprecate A --to B --reason duplicate` marks A; `ref show A` reports the successor
+- [x] `ref export --all` includes A on stdout and warns on stderr; `ref export --all 2>/dev/null`
       is byte-identical to the pre-mark output
-- [ ] `ref list` omits A; `ref list --include-superseded` shows it
-- [ ] `ref deprecate B --to A` is rejected as a cycle
-- [ ] `ref update A --set custom.superseded_by=X` is rejected as a protected field
-- [ ] `ref deprecate A --unset` clears all three fields
+- [x] `ref list` omits A; `ref list --include-superseded` shows it
+- [x] `ref deprecate B --to A` is rejected as a cycle
+- [x] `ref update A --set custom.superseded_by=X` is rejected as a protected field
+- [x] `ref deprecate A --unset` clears all three fields
 
 ## Completion Checklist
 

--- a/spec/tasks/20260807-02-superseded-pointers.md
+++ b/spec/tasks/20260807-02-superseded-pointers.md
@@ -1,0 +1,132 @@
+# Task: Superseded Pointers — `custom.superseded_by` and `ref deprecate` (#108, PR-1)
+
+## Purpose
+
+Give the library a way to say "do not cite this one, cite that one" (issue #108). This is PR-1 of
+three; it delivers the data model, the `ref deprecate` command, and reference-time warnings. That is
+enough to handle the conference-version → journal-version case by hand, which no automatic detector
+can reach.
+
+Follow-up PRs (not in scope here):
+
+- PR-2: `ref duplicates [--by ...] [--fix]` — retroactive scan, applies marks in bulk
+- PR-3: `check --fix` action that adds the published version as a new record and marks the old one
+
+## References
+
+- Issue: #108
+- Spec: `spec/features/superseded.md`
+- Related: `src/core/csl-json/types.ts` (`CslCustomSchema`),
+  `src/core/library-interface.ts` (`MANAGED_CUSTOM_FIELDS`),
+  `src/cli/commands/update.ts` (`PROTECTED_FIELDS`),
+  `src/features/operations/list.ts`, `src/cli/commands/{show,cite,export,list,search}.ts`
+
+## Decisions
+
+Settled before implementation:
+
+1. **`superseded_by` stores the successor's uuid**, not its citation key. Keys are renamed by
+   collision resolution (`src/core/library.ts`, `resolveNewId`), so a key-valued pointer dangles
+   silently. Display resolves uuid → key.
+2. **`export` includes superseded records and warns; `list` hides them** behind
+   `--include-superseded`. Excluding from `export` would break manuscripts that still cite the old
+   key — the failure would surface as an unresolved citeproc key rather than a warning.
+3. The three fields join `MANAGED_CUSTOM_FIELDS` (not `PROTECTED_CUSTOM_FIELDS`), making
+   `ref deprecate` the only writer while keeping the mark visible to change detection.
+
+## TDD Workflow
+
+For each step, follow the Red-Green-Refactor cycle (see `spec/guidelines/testing.md`).
+
+## Steps
+
+### Step 1: Schema and field protection
+
+- [ ] Write test: `src/core/csl-json/types.test.ts` — `superseded_by` / `superseded_reason` /
+      `superseded_at` parse, reason is a union, partial marks still parse (other software writes
+      `custom` freely)
+- [ ] Add the three fields to `CslCustomSchema` (`src/core/csl-json/types.ts`)
+- [ ] Add them to `MANAGED_CUSTOM_FIELDS` (`src/core/library-interface.ts`)
+- [ ] Write test: `src/cli/commands/update.test.ts` — `update --set custom.superseded_by=x` is
+      rejected as a protected field
+- [ ] Write test: `src/cli/commands/edit.test.ts` — an edit that drops or rewrites the fields keeps
+      the original values
+- [ ] Verify Green + `npm run lint && npm run typecheck`
+
+### Step 2: Resolution module (`src/features/superseded/`)
+
+- [ ] Write test: `src/features/superseded/resolver.test.ts`
+  - `getSupersededMark(item)` → mark or null; partial marks treated as absent
+  - `resolveSuccessor(item, allItems)` → `{ target, dangling }`
+  - `resolveFinalSuccessor(item, allItems)` → end of chain, terminates on a cycle rather than
+    looping forever (defensive: `deprecate` prevents cycles, hand-edited files may not)
+  - `isSuperseded(item)`
+- [ ] Create stub, verify Red, implement, verify Green
+- [ ] Write test: `src/features/superseded/warning.test.ts` — `formatSupersededWarning` for the
+      resolved, dangling, and chained cases
+- [ ] Implement, verify Green
+- [ ] Lint/Type check
+
+### Step 3: `ref deprecate` command
+
+- [ ] Write test: `src/features/operations/deprecate.test.ts` — operation layer: set, unset,
+      overwrite existing mark, self-reference rejected, cycle rejected, unknown old id, unknown
+      target, unset on unmarked record is a no-op
+- [ ] Create stub `src/features/operations/deprecate.ts`, verify Red, implement, verify Green
+- [ ] Write test: `src/cli/commands/deprecate.test.ts` — option parsing (`--to` / `--unset` mutual
+      exclusion, `--reason` default `other`, `--uuid`), exit codes, text and `-o json` output
+- [ ] Implement `src/cli/commands/deprecate.ts`, register in `src/cli/index.ts`
+- [ ] Verify Green + lint/typecheck
+
+### Step 4: Reference-time warnings
+
+- [ ] Write test: `src/cli/commands/show.test.ts` — stderr warning; pretty output has a
+      `Superseded by` line; stdout unchanged in json mode
+- [ ] Write test: `src/cli/commands/cite.test.ts` — one warning per cited superseded record
+- [ ] Write test: `src/cli/commands/search.test.ts` — warns, does not filter
+- [ ] Write test: `src/cli/commands/export.test.ts` — includes the record, warns per record, prints
+      the summary line, stdout byte-identical to the unmarked case
+- [ ] Implement the warning emission in each command
+- [ ] Verify Green + lint/typecheck
+
+### Step 5: `list` filtering
+
+- [ ] Write test: `src/features/operations/list.test.ts` — superseded excluded by default,
+      `includeSuperseded` restores them, `total` reflects the filter
+- [ ] Implement `includeSuperseded` in `listReferences`
+- [ ] Write test: `src/cli/commands/list.test.ts` — `--include-superseded` flag, warning emitted
+      only when they are shown
+- [ ] Implement flag in `src/cli/index.ts` / `src/cli/commands/list.ts`
+- [ ] Verify Green + lint/typecheck
+
+### Step 6: Shell completion and docs
+
+- [ ] Add `deprecate` to shell completion (`src/features/install` / completion source — check where
+      commands are enumerated)
+- [ ] Update `spec/_index.md` command table with `deprecate` → `spec/features/superseded.md`
+- [ ] Update `spec/core/data-model.md` with the three reserved fields
+- [ ] Update README if it lists commands
+
+## Manual Verification
+
+**Script**: `test-fixtures/test-superseded.sh`
+
+Non-TTY tests (automated):
+- [ ] `ref deprecate A --to B --reason duplicate` marks A; `ref show A` reports the successor
+- [ ] `ref export --all` includes A on stdout and warns on stderr; `ref export --all 2>/dev/null`
+      is byte-identical to the pre-mark output
+- [ ] `ref list` omits A; `ref list --include-superseded` shows it
+- [ ] `ref deprecate B --to A` is rejected as a cycle
+- [ ] `ref update A --set custom.superseded_by=X` is rejected as a protected field
+- [ ] `ref deprecate A --unset` clears all three fields
+
+## Completion Checklist
+
+- [ ] All tests pass (`npm run test`)
+- [ ] Lint passes (`npm run lint`)
+- [ ] Type check passes (`npm run typecheck`)
+- [ ] Build succeeds (`npm run build`)
+- [ ] Manual verification: `./test-fixtures/test-superseded.sh`
+- [ ] CHANGELOG.md updated
+- [ ] PR description references #108 (do **not** close it — PR-2 and PR-3 remain)
+- [ ] Move this file to `spec/tasks/completed/` when all three PRs land

--- a/src/cli/commands/cite.ts
+++ b/src/cli/commands/cite.ts
@@ -1,4 +1,5 @@
 import type { Config } from "../../config/schema.js";
+import type { CslItem } from "../../core/csl-json/types.js";
 import { Library } from "../../core/library.js";
 import type { CiteOperationOptions, CiteResult } from "../../features/operations/cite.js";
 import { type ExecutionContext, createExecutionContext } from "../execution-context.js";
@@ -11,6 +12,7 @@ import {
   setExitCode,
   writeOutputWithClipboard,
 } from "../helpers.js";
+import { reportSuperseded } from "../superseded-report.js";
 
 /**
  * Options for the cite command.
@@ -194,6 +196,29 @@ async function executeInteractiveCite(
 /**
  * Handle 'cite' command action.
  */
+/**
+ * Look the cited references back up so superseded ones can be reported.
+ *
+ * `CiteResult` carries only the rendered citation strings, and the identifier count here is
+ * whatever the user typed (or selected) — a handful — so per-identifier lookups are cheaper
+ * than reshaping the operation's result type.
+ */
+async function resolveCitedItems(
+  result: CiteCommandResult,
+  context: ExecutionContext,
+  useUuid: boolean
+): Promise<CslItem[]> {
+  const items: CslItem[] = [];
+  for (const r of result.results) {
+    if (!r.success) continue;
+    const item = await context.library.find(r.identifier, { idType: useUuid ? "uuid" : "id" });
+    if (item) {
+      items.push(item);
+    }
+  }
+  return items;
+}
+
 export async function handleCiteAction(
   identifiers: string[],
   options: Omit<CiteCommandOptions, "identifiers">,
@@ -237,6 +262,14 @@ export async function handleCiteAction(
     if (errors) {
       process.stderr.write(`${errors}\n`);
     }
+
+    await reportSuperseded(
+      await resolveCitedItems(result, context, options.uuid ?? false),
+      context,
+      {
+        silent: config.logLevel === "silent",
+      }
+    );
 
     setExitCode(getCiteExitCode(result));
   } catch (error) {

--- a/src/cli/commands/deprecate.test.ts
+++ b/src/cli/commands/deprecate.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CslItem } from "../../core/csl-json/types.js";
+import type { ExecutionContext } from "../execution-context.js";
+import {
+  type DeprecateCommandResult,
+  executeDeprecate,
+  formatDeprecateOutput,
+  validateDeprecateOptions,
+} from "./deprecate.js";
+
+const mockDeprecateReference = vi.fn();
+vi.mock("../../features/operations/deprecate.js", () => ({
+  deprecateReference: (...args: unknown[]) => mockDeprecateReference(...args),
+}));
+
+function item(id: string, uuid: string, custom: Record<string, unknown> = {}): CslItem {
+  return { id, type: "article-journal", title: id, custom: { uuid, ...custom } };
+}
+
+describe("validateDeprecateOptions", () => {
+  it("accepts --to on its own", () => {
+    expect(validateDeprecateOptions({ to: "B" })).toBeNull();
+  });
+
+  it("accepts --to with a known reason", () => {
+    expect(validateDeprecateOptions({ to: "B", reason: "duplicate" })).toBeNull();
+    expect(validateDeprecateOptions({ to: "B", reason: "published_version" })).toBeNull();
+    expect(validateDeprecateOptions({ to: "B", reason: "other" })).toBeNull();
+  });
+
+  it("accepts --unset on its own", () => {
+    expect(validateDeprecateOptions({ unset: true })).toBeNull();
+  });
+
+  it("rejects --to together with --unset", () => {
+    expect(validateDeprecateOptions({ to: "B", unset: true })).toBe(
+      "Cannot use --to and --unset together."
+    );
+  });
+
+  it("rejects neither --to nor --unset", () => {
+    expect(validateDeprecateOptions({})).toBe(
+      "Nothing to do. Use --to <id> to set a successor, or --unset to clear one."
+    );
+  });
+
+  it("rejects --reason with --unset", () => {
+    expect(validateDeprecateOptions({ unset: true, reason: "duplicate" })).toBe(
+      "--reason has no meaning with --unset."
+    );
+  });
+
+  it("rejects an unknown reason", () => {
+    expect(validateDeprecateOptions({ to: "B", reason: "merged" })).toBe(
+      "Invalid --reason: merged. Expected one of: duplicate, published_version, other."
+    );
+  });
+});
+
+describe("executeDeprecate", () => {
+  const context = { library: {} } as unknown as ExecutionContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeprecateReference.mockResolvedValue({ applied: true });
+  });
+
+  it("passes the successor and reason through", async () => {
+    await executeDeprecate({ identifier: "A", target: "B", reason: "duplicate" }, context);
+
+    expect(mockDeprecateReference).toHaveBeenCalledWith(context.library, {
+      identifier: "A",
+      idType: "id",
+      target: "B",
+      reason: "duplicate",
+      unset: false,
+    });
+  });
+
+  it("passes uuid lookup through", async () => {
+    await executeDeprecate({ identifier: "uuid-a", target: "uuid-b", idType: "uuid" }, context);
+
+    expect(mockDeprecateReference).toHaveBeenCalledWith(
+      context.library,
+      expect.objectContaining({ idType: "uuid" })
+    );
+  });
+
+  it("omits target and reason when clearing", async () => {
+    await executeDeprecate({ identifier: "A", unset: true }, context);
+
+    expect(mockDeprecateReference).toHaveBeenCalledWith(context.library, {
+      identifier: "A",
+      idType: "id",
+      unset: true,
+    });
+  });
+});
+
+describe("formatDeprecateOutput", () => {
+  it("reports a mark that was set", () => {
+    const result: DeprecateCommandResult = {
+      applied: true,
+      item: item("A", "uuid-a", { superseded_reason: "duplicate" }),
+      target: item("B", "uuid-b"),
+    };
+
+    expect(formatDeprecateOutput(result, "A")).toBe("Marked A as superseded by B (duplicate).");
+  });
+
+  it("reports a mark that was cleared", () => {
+    const result: DeprecateCommandResult = { applied: true, item: item("A", "uuid-a") };
+
+    expect(formatDeprecateOutput(result, "A")).toBe("Cleared the superseded mark from A.");
+  });
+
+  it("reports a no-op unset", () => {
+    const result: DeprecateCommandResult = {
+      applied: false,
+      item: item("A", "uuid-a"),
+      noop: true,
+    };
+
+    expect(formatDeprecateOutput(result, "A")).toBe("A is not marked as superseded.");
+  });
+
+  // The reference may have been looked up by uuid, so report the citation key the library
+  // actually holds rather than echoing the identifier back.
+  it("names the reference by its citation key, not the identifier given", () => {
+    const result: DeprecateCommandResult = {
+      applied: true,
+      item: item("Carless2020-yj", "uuid-a", { superseded_reason: "other" }),
+      target: item("Carless2023-yt", "uuid-b"),
+    };
+
+    expect(formatDeprecateOutput(result, "uuid-a")).toBe(
+      "Marked Carless2020-yj as superseded by Carless2023-yt (other)."
+    );
+  });
+});

--- a/src/cli/commands/deprecate.ts
+++ b/src/cli/commands/deprecate.ts
@@ -1,0 +1,183 @@
+import { SUPERSEDED_REASONS, type SupersededReason } from "../../core/csl-json/types.js";
+import type { IdentifierType } from "../../core/library-interface.js";
+import { Library } from "../../core/library.js";
+import { type DeprecateResult, deprecateReference } from "../../features/operations/deprecate.js";
+import { type ExecutionContext, createExecutionContext } from "../execution-context.js";
+import { ExitCode, loadConfigWithOverrides, setExitCode } from "../helpers.js";
+
+/**
+ * Options for the deprecate command.
+ */
+export interface DeprecateCommandOptions {
+  identifier: string;
+  /** Successor identifier (`--to`) */
+  target?: string;
+  reason?: SupersededReason;
+  unset?: boolean;
+  idType?: IdentifierType;
+}
+
+export type DeprecateCommandResult = DeprecateResult;
+
+/**
+ * Execute the deprecate command.
+ *
+ * `deprecateReference` only touches ILibrary methods, so this works unchanged in server mode.
+ */
+export async function executeDeprecate(
+  options: DeprecateCommandOptions,
+  context: ExecutionContext
+): Promise<DeprecateCommandResult> {
+  const { identifier, target, reason, unset = false, idType = "id" } = options;
+
+  return deprecateReference(context.library, {
+    identifier,
+    idType,
+    ...(target !== undefined && { target }),
+    ...(reason !== undefined && { reason }),
+    unset,
+  });
+}
+
+/**
+ * Validate the option combination before touching the library.
+ *
+ * @returns An error message, or null when the combination is usable
+ */
+export function validateDeprecateOptions(options: {
+  to?: string | undefined;
+  unset?: boolean | undefined;
+  reason?: string | undefined;
+}): string | null {
+  const hasTarget = options.to !== undefined;
+  const unset = options.unset === true;
+
+  if (hasTarget && unset) {
+    return "Cannot use --to and --unset together.";
+  }
+  if (!hasTarget && !unset) {
+    return "Nothing to do. Use --to <id> to set a successor, or --unset to clear one.";
+  }
+  if (unset && options.reason !== undefined) {
+    return "--reason has no meaning with --unset.";
+  }
+  if (
+    options.reason !== undefined &&
+    !(SUPERSEDED_REASONS as readonly string[]).includes(options.reason)
+  ) {
+    return `Invalid --reason: ${options.reason}. Expected one of: ${SUPERSEDED_REASONS.join(", ")}.`;
+  }
+
+  return null;
+}
+
+/**
+ * Human-readable result line for text output. Written to stderr, like other mutation commands.
+ */
+export function formatDeprecateOutput(result: DeprecateCommandResult, identifier: string): string {
+  if (result.noop) {
+    return `${result.item?.id ?? identifier} is not marked as superseded.`;
+  }
+  if (result.target) {
+    const reason = result.item?.custom?.superseded_reason ?? "other";
+    return `Marked ${result.item?.id ?? identifier} as superseded by ${result.target.id} (${reason}).`;
+  }
+  return `Cleared the superseded mark from ${result.item?.id ?? identifier}.`;
+}
+
+export interface DeprecateActionOptions {
+  to?: string;
+  unset?: boolean;
+  reason?: string;
+  uuid?: boolean;
+  output?: string;
+  full?: boolean;
+  [key: string]: unknown;
+}
+
+/**
+ * Report a failure that happened before or around the operation itself.
+ * In JSON mode the error is the payload, so it goes to stdout like any other result.
+ */
+function writeDeprecateFailure(message: string, identifier: string, asJson: boolean): void {
+  if (asJson) {
+    process.stdout.write(
+      `${JSON.stringify({ success: false, id: identifier, error: message }, null, 2)}\n`
+    );
+  } else {
+    process.stderr.write(`Error: ${message}\n`);
+  }
+}
+
+/** Report the outcome of a completed operation. */
+async function writeDeprecateResult(
+  result: DeprecateCommandResult,
+  identifier: string,
+  options: DeprecateActionOptions,
+  asJson: boolean
+): Promise<void> {
+  const { describeDeprecateError, formatDeprecateJsonOutput } = await import(
+    "../../features/operations/json-output.js"
+  );
+
+  if (asJson) {
+    const json = formatDeprecateJsonOutput(result, identifier, options.to, {
+      full: options.full ?? false,
+    });
+    process.stdout.write(`${JSON.stringify(json, null, 2)}\n`);
+    return;
+  }
+
+  if (result.errorType) {
+    process.stderr.write(
+      `Error: ${describeDeprecateError(result.errorType, identifier, options.to)}\n`
+    );
+    return;
+  }
+
+  process.stderr.write(`${formatDeprecateOutput(result, identifier)}\n`);
+}
+
+/**
+ * Handle the `deprecate` command.
+ */
+export async function handleDeprecateAction(
+  identifier: string,
+  options: DeprecateActionOptions,
+  globalOpts: Record<string, unknown>
+): Promise<void> {
+  const asJson = (options.output ?? "text") === "json";
+
+  const optionError = validateDeprecateOptions(options);
+  if (optionError) {
+    writeDeprecateFailure(optionError, identifier, asJson);
+    setExitCode(ExitCode.ERROR);
+    return;
+  }
+
+  try {
+    const config = await loadConfigWithOverrides({ ...globalOpts, ...options });
+    const context = await createExecutionContext(config, Library.load);
+
+    const result = await executeDeprecate(
+      {
+        identifier,
+        ...(options.to !== undefined && { target: options.to }),
+        ...(options.reason !== undefined && { reason: options.reason as SupersededReason }),
+        unset: options.unset ?? false,
+        idType: options.uuid ? "uuid" : "id",
+      },
+      context
+    );
+
+    await writeDeprecateResult(result, identifier, options, asJson);
+    setExitCode(result.errorType ? ExitCode.ERROR : ExitCode.SUCCESS);
+  } catch (error) {
+    writeDeprecateFailure(
+      error instanceof Error ? error.message : String(error),
+      identifier,
+      asJson
+    );
+    setExitCode(ExitCode.INTERNAL_ERROR);
+  }
+}

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -39,6 +39,8 @@ export interface ListCommandOptions {
   order?: SortOrder;
   limit?: number;
   offset?: number;
+  /** Include references marked as superseded (#108); hidden by default */
+  includeSuperseded?: boolean;
 }
 
 /**
@@ -143,7 +145,7 @@ export async function executeList(
 
   return context.library.list({
     ...(sort !== undefined && { sort }),
-    ...pickDefined(options, ["order", "limit", "offset"] as const),
+    ...pickDefined(options, ["order", "limit", "offset", "includeSuperseded"] as const),
   });
 }
 

--- a/src/cli/commands/show.ts
+++ b/src/cli/commands/show.ts
@@ -11,6 +11,7 @@ import { Library } from "../../core/library.js";
 import { formatBibtex } from "../../features/format/bibtex.js";
 import { normalizeReference } from "../../features/format/show-normalizer.js";
 import { formatShowPretty } from "../../features/format/show-pretty.js";
+import { isSuperseded } from "../../features/superseded/index.js";
 import { type ExecutionContext, createExecutionContext } from "../execution-context.js";
 import {
   ExitCode,
@@ -21,6 +22,7 @@ import {
   setExitCode,
   writeOutputWithClipboard,
 } from "../helpers.js";
+import { reportSuperseded } from "../superseded-report.js";
 
 export interface ShowCommandOptions {
   uuid?: boolean;
@@ -40,10 +42,17 @@ export async function executeShow(
 export function formatShowOutput(
   item: CslItem,
   options: ShowCommandOptions,
-  attachmentsDirectory?: string
+  attachmentsDirectory?: string,
+  allItems?: CslItem[]
 ): string {
   const format = options.json ? "json" : (options.output ?? "pretty");
-  const normalizeOpts = attachmentsDirectory ? { attachmentsDirectory } : undefined;
+  const normalizeOpts =
+    attachmentsDirectory || allItems
+      ? {
+          ...(attachmentsDirectory && { attachmentsDirectory }),
+          ...(allItems && { allItems }),
+        }
+      : undefined;
 
   if (format === "json") {
     const normalized = normalizeReference(item, normalizeOpts);
@@ -111,10 +120,16 @@ export async function handleShowAction(
       return;
     }
 
-    const output = formatShowOutput(item, options, config.attachments.directory);
+    // Only fetch the library when this record actually points somewhere — resolving the
+    // successor's citation key needs it, but the common case is an unmarked record.
+    const allItems = isSuperseded(item) ? await context.library.getAll() : undefined;
+
+    const output = formatShowOutput(item, options, config.attachments.directory, allItems);
     if (output) {
       await writeOutputWithClipboard(output, false, config.logLevel === "silent");
     }
+
+    await reportSuperseded([item], context, { silent: config.logLevel === "silent" });
 
     setExitCode(ExitCode.SUCCESS);
   } catch (error) {

--- a/src/cli/commands/update.test.ts
+++ b/src/cli/commands/update.test.ts
@@ -419,6 +419,17 @@ describe("update command", () => {
       expect(() => applySetOperations(operations)).toThrow("Cannot set protected field");
     });
 
+    // `ref deprecate` is the only writer for these — a hand-set value would bypass the
+    // successor-exists and cycle checks (#108).
+    it.each(["custom.superseded_by", "custom.superseded_reason", "custom.superseded_at"])(
+      "should throw on protected field (%s)",
+      (field) => {
+        const operations: SetOperation[] = [{ field, operator: "=", value: "x" }];
+
+        expect(() => applySetOperations(operations)).toThrow("Cannot set protected field");
+      }
+    );
+
     it("should throw on unsupported field", () => {
       const operations: SetOperation[] = [
         { field: "unsupported_field", operator: "=", value: "value" },

--- a/src/cli/completion.ts
+++ b/src/cli/completion.ts
@@ -111,7 +111,7 @@ function getOptionValuesForCommand(
 }
 
 // Commands that support ID completion
-const ID_COMPLETION_COMMANDS = new Set(["cite", "remove", "update"]);
+const ID_COMPLETION_COMMANDS = new Set(["cite", "deprecate", "remove", "update"]);
 const ID_COMPLETION_FULLTEXT_SUBCOMMANDS = new Set(["attach", "get", "detach", "open"]);
 const ID_COMPLETION_ATTACH_SUBCOMMANDS = new Set(["open", "add", "list", "get", "detach", "sync"]);
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -31,6 +31,7 @@ import {
 import { handleCheckAction } from "./commands/check.js";
 import { handleCiteAction } from "./commands/cite.js";
 import { registerConfigCommand } from "./commands/config.js";
+import { handleDeprecateAction } from "./commands/deprecate.js";
 import { handleEditAction } from "./commands/edit.js";
 import {
   type ExportCommandOptions,
@@ -124,6 +125,7 @@ export function createProgram(): Command {
   registerAddCommand(program);
   registerRemoveCommand(program);
   registerUpdateCommand(program);
+  registerDeprecateCommand(program);
   registerEditCommand(program);
   registerCheckCommand(program);
   registerCiteCommand(program);
@@ -582,6 +584,30 @@ function registerUpdateCommand(program: Command): void {
     .option("--full", "Include full CSL-JSON data in JSON output")
     .action(async (identifier: string | undefined, file: string | undefined, options) => {
       await handleUpdateAction(identifier, file, options, program.opts());
+    });
+}
+
+/**
+ * Register 'deprecate' command
+ */
+function registerDeprecateCommand(program: Command): void {
+  program
+    .command("deprecate")
+    .description(
+      "Mark a reference as superseded by another.\n\n" +
+        "The record stays in the library so manuscripts that already cite its key keep\n" +
+        "resolving; read commands report the successor on stderr. See\n" +
+        "spec/features/superseded.md."
+    )
+    .argument("<identifier>", "Citation key or UUID of the reference to mark")
+    .option("--to <identifier>", "Citation key or UUID of the successor")
+    .option("--unset", "Clear an existing superseded mark")
+    .option("--reason <reason>", "Why: duplicate|published_version|other (default: other)")
+    .option("--uuid", "Interpret both identifiers as UUIDs")
+    .option("-o, --output <format>", "Output format: json|text", "text")
+    .option("--full", "Include full CSL-JSON data in JSON output")
+    .action(async (identifier: string, options) => {
+      await handleDeprecateAction(identifier, options, program.opts());
     });
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -78,6 +78,7 @@ import {
   setExitCode,
   writeOutputWithClipboard,
 } from "./helpers.js";
+import { reportSuperseded } from "./superseded-report.js";
 
 /**
  * Create Commander program instance
@@ -159,6 +160,9 @@ async function handleListAction(options: ListCommandOptions, program: Command): 
       await writeOutputWithClipboard(output, clipboardEnabled, config.logLevel === "silent");
     }
 
+    // Only reachable with --include-superseded; without it nothing superseded is in `items`.
+    await reportSuperseded(result.items, context, { silent: config.logLevel === "silent" });
+
     setExitCode(ExitCode.SUCCESS);
   } catch (error) {
     exitWithError(error instanceof Error ? error.message : String(error), ExitCode.INTERNAL_ERROR);
@@ -187,6 +191,7 @@ function registerListCommand(program: Command): void {
     .option("--order <order>", "Sort order: asc|desc")
     .option("-n, --limit <n>", "Maximum number of results", Number.parseInt)
     .option("--offset <n>", "Number of results to skip", Number.parseInt)
+    .option("--include-superseded", "Include references marked as superseded")
     .action(async (options) => {
       await handleListAction(options, program);
     });
@@ -235,6 +240,14 @@ async function handleExportAction(
         process.stderr.write(`Error: Reference not found: ${id}\n`);
       }
     }
+
+    // Superseded records stay in the output: dropping one would break a manuscript that still
+    // cites its key, turning a warning into an unresolved citeproc reference.
+    await reportSuperseded(result.items, context, {
+      silent: config.logLevel === "silent",
+      summary: (count) =>
+        `${count} superseded reference${count === 1 ? "" : "s"} included. Update your manuscript keys.`,
+    });
 
     setExitCode(getExportExitCode(result));
   } catch (error) {
@@ -302,6 +315,10 @@ async function handleSearchAction(
     } else if (result.items.length === 0 && query) {
       process.stderr.write(`${buildNoResultsHintText(query)}\n`);
     }
+
+    // Warn but do not filter: search is an explicit query, and silently dropping a record the
+    // user asked for by name would be surprising (spec/features/superseded.md).
+    await reportSuperseded(result.items, context, { silent: config.logLevel === "silent" });
 
     setExitCode(ExitCode.SUCCESS);
   } catch (error) {

--- a/src/cli/superseded-report.test.ts
+++ b/src/cli/superseded-report.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CslItem } from "../core/csl-json/types.js";
+import type { ExecutionContext } from "./execution-context.js";
+import { reportSuperseded } from "./superseded-report.js";
+
+function item(id: string, uuid: string, custom: Record<string, unknown> = {}): CslItem {
+  return { id, type: "article-journal", title: id, custom: { uuid, ...custom } };
+}
+
+function mark(uuid: string, reason = "duplicate"): Record<string, unknown> {
+  return {
+    superseded_by: uuid,
+    superseded_reason: reason,
+    superseded_at: "2026-08-07T00:00:00.000Z",
+  };
+}
+
+describe("reportSuperseded", () => {
+  let stderr: string[];
+  let stdout: string[];
+  let getAll: ReturnType<typeof vi.fn>;
+  let context: ExecutionContext;
+
+  function useLibrary(items: CslItem[]): void {
+    getAll = vi.fn().mockResolvedValue(items);
+    context = { library: { getAll } } as unknown as ExecutionContext;
+  }
+
+  beforeEach(() => {
+    stderr = [];
+    stdout = [];
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderr.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("writes one line per superseded reference", async () => {
+    const old = item("Carless2020-yj", "uuid-old", mark("uuid-new"));
+    const current = item("Carless2023-yt", "uuid-new");
+    useLibrary([old, current]);
+
+    const count = await reportSuperseded([old, current], context);
+
+    expect(count).toBe(1);
+    expect(stderr).toEqual(["[SUPERSEDED] Carless2020-yj -> Carless2023-yt (duplicate)\n"]);
+  });
+
+  // stdout is the contract for piping into pandoc, jq, and friends.
+  it("never writes to stdout", async () => {
+    const old = item("A", "uuid-old", mark("uuid-new"));
+    useLibrary([old, item("B", "uuid-new")]);
+
+    await reportSuperseded([old], context);
+
+    expect(stdout).toEqual([]);
+  });
+
+  it("appends a summary line when one is given", async () => {
+    const old = item("A", "uuid-old", mark("uuid-new"));
+    useLibrary([old, item("B", "uuid-new")]);
+
+    await reportSuperseded([old], context, { summary: (n) => `${n} included.` });
+
+    expect(stderr.at(-1)).toBe("1 included.\n");
+  });
+
+  it("resolves against the whole library, not just the shown items", async () => {
+    const old = item("A", "uuid-old", mark("uuid-new"));
+    useLibrary([old, item("B", "uuid-new")]);
+
+    await reportSuperseded([old], context);
+
+    expect(stderr[0]).toContain("-> B");
+  });
+
+  // Every read command calls this, so the unmarked case must not cost a library fetch.
+  it("does not fetch the library when nothing is superseded", async () => {
+    useLibrary([item("A", "uuid-a")]);
+
+    const count = await reportSuperseded([item("A", "uuid-a")], context);
+
+    expect(count).toBe(0);
+    expect(getAll).not.toHaveBeenCalled();
+    expect(stderr).toEqual([]);
+  });
+
+  it("writes nothing in silent mode", async () => {
+    const old = item("A", "uuid-old", mark("uuid-new"));
+    useLibrary([old, item("B", "uuid-new")]);
+
+    const count = await reportSuperseded([old], context, { silent: true });
+
+    expect(count).toBe(0);
+    expect(stderr).toEqual([]);
+    expect(getAll).not.toHaveBeenCalled();
+  });
+
+  it("returns zero for an empty item list", async () => {
+    useLibrary([]);
+
+    expect(await reportSuperseded([], context)).toBe(0);
+  });
+});

--- a/src/cli/superseded-report.ts
+++ b/src/cli/superseded-report.ts
@@ -1,0 +1,53 @@
+/**
+ * stderr reporting for superseded references (#108).
+ *
+ * Read commands call this after writing their own output. Warnings never touch stdout, so
+ * piping `ref export`, `ref cite`, or `ref list --output ids` stays byte-identical to the
+ * unmarked case. See spec/features/superseded.md.
+ */
+
+import type { CslItem } from "../core/csl-json/types.js";
+import { collectSupersededWarnings, isSuperseded } from "../features/superseded/index.js";
+import type { ExecutionContext } from "./execution-context.js";
+
+export interface ReportSupersededOptions {
+  /** Suppress all output (config.logLevel === "silent") */
+  silent?: boolean;
+  /** Extra line written after the per-record warnings, when any were written */
+  summary?: (count: number) => string;
+}
+
+/**
+ * Write one `[SUPERSEDED]` line per superseded reference in `items`.
+ *
+ * @returns How many references were superseded
+ */
+export async function reportSuperseded(
+  items: CslItem[],
+  context: ExecutionContext,
+  options: ReportSupersededOptions = {}
+): Promise<number> {
+  if (options.silent) {
+    return 0;
+  }
+
+  const marked = items.filter(isSuperseded);
+  if (marked.length === 0) {
+    return 0;
+  }
+
+  // Fetch the library only once something is actually marked: a pointer may target a record
+  // outside the shown set, so resolution needs the whole library, but the common case is that
+  // nothing is superseded and no command should pay for a full fetch to find that out.
+  const allItems = await context.library.getAll();
+
+  for (const line of collectSupersededWarnings(marked, allItems)) {
+    process.stderr.write(`${line}\n`);
+  }
+
+  if (options.summary) {
+    process.stderr.write(`${options.summary(marked.length)}\n`);
+  }
+
+  return marked.length;
+}

--- a/src/core/csl-json/types.test.ts
+++ b/src/core/csl-json/types.test.ts
@@ -160,6 +160,71 @@ describe("CslCustomSchema typed fields", () => {
     });
   });
 
+  describe("superseded fields", () => {
+    it("accepts a complete superseded mark", () => {
+      const result = CslItemSchema.parse({
+        ...baseItem,
+        custom: {
+          superseded_by: "018f2c9a-1234-7890-abcd-000000000001",
+          superseded_reason: "duplicate",
+          superseded_at: "2026-08-07T00:00:00.000Z",
+        },
+      });
+      expect(result.custom?.superseded_by).toBe("018f2c9a-1234-7890-abcd-000000000001");
+      expect(result.custom?.superseded_reason).toBe("duplicate");
+      expect(result.custom?.superseded_at).toBe("2026-08-07T00:00:00.000Z");
+    });
+
+    it("accepts each known reason", () => {
+      for (const reason of ["duplicate", "published_version", "other"]) {
+        const result = CslItemSchema.parse({
+          ...baseItem,
+          custom: {
+            superseded_by: "uuid-1",
+            superseded_reason: reason,
+            superseded_at: "2026-01-01",
+          },
+        });
+        expect(result.custom?.superseded_reason).toBe(reason);
+      }
+    });
+
+    // The storage schema stays permissive: a reason written by another tool must not make the
+    // whole library fail to load. `ref deprecate` enforces the union at the CLI boundary.
+    it("accepts an unknown reason rather than failing the parse", () => {
+      const result = CslItemSchema.parse({
+        ...baseItem,
+        custom: {
+          superseded_by: "uuid-1",
+          superseded_reason: "merged",
+          superseded_at: "2026-01-01",
+        },
+      });
+      expect(result.custom?.superseded_reason).toBe("merged");
+    });
+
+    it("accepts a partial mark", () => {
+      const result = CslItemSchema.parse({
+        ...baseItem,
+        custom: { superseded_by: "uuid-1" },
+      });
+      expect(result.custom?.superseded_by).toBe("uuid-1");
+      expect(result.custom?.superseded_reason).toBeUndefined();
+      expect(result.custom?.superseded_at).toBeUndefined();
+    });
+
+    it("is optional", () => {
+      const result = CslItemSchema.parse({ ...baseItem, custom: {} });
+      expect(result.custom?.superseded_by).toBeUndefined();
+    });
+
+    it("rejects a non-string superseded_by", () => {
+      expect(() =>
+        CslItemSchema.parse({ ...baseItem, custom: { superseded_by: 12345 } })
+      ).toThrow();
+    });
+  });
+
   describe("validation", () => {
     it("rejects invalid attachments structure", () => {
       expect(() =>

--- a/src/core/csl-json/types.ts
+++ b/src/core/csl-json/types.ts
@@ -62,8 +62,22 @@ const CslCustomSchema = z
     scopus_id: z.string().optional(),
     attachments: AttachmentsSchema.optional(),
     check: CheckDataSchema.optional(),
+    // Successor pointer (#108). Holds the successor's uuid, not its citation key —
+    // keys are renamed by collision resolution, so a key-valued pointer would dangle
+    // silently. See spec/features/superseded.md.
+    superseded_by: z.string().optional(),
+    // Kept as a free string rather than an enum: a reason written by another tool
+    // must not make the whole library fail to load. `ref deprecate` enforces the
+    // SUPERSEDED_REASONS union at the CLI boundary.
+    superseded_reason: z.string().optional(),
+    superseded_at: z.string().optional(),
   })
   .passthrough();
+
+/** Reasons `ref deprecate` accepts for `custom.superseded_reason`. */
+export const SUPERSEDED_REASONS = ["duplicate", "published_version", "other"] as const;
+
+export type SupersededReason = (typeof SUPERSEDED_REASONS)[number];
 
 // CSL-JSON Item
 export const CslItemSchema = z

--- a/src/core/library-interface.ts
+++ b/src/core/library-interface.ts
@@ -91,8 +91,19 @@ export const PROTECTED_CUSTOM_FIELDS = new Set(["uuid", "created_at", "timestamp
 /**
  * Custom fields excluded from user display/edit.
  * Superset of PROTECTED_CUSTOM_FIELDS — also hides fields that users should not manually edit.
+ *
+ * The superseded_* fields are here so `ref deprecate` is their only writer: hand-editing them
+ * would bypass the successor-exists and cycle checks. They are deliberately NOT in
+ * PROTECTED_CUSTOM_FIELDS, so marking a reference still registers as a real change.
+ * See spec/features/superseded.md.
  */
-export const MANAGED_CUSTOM_FIELDS = new Set([...PROTECTED_CUSTOM_FIELDS, "attachments"]);
+export const MANAGED_CUSTOM_FIELDS = new Set([
+  ...PROTECTED_CUSTOM_FIELDS,
+  "attachments",
+  "superseded_by",
+  "superseded_reason",
+  "superseded_at",
+]);
 
 /**
  * Common interface for library implementations.

--- a/src/features/edit/yaml-serializer.test.ts
+++ b/src/features/edit/yaml-serializer.test.ts
@@ -65,6 +65,26 @@ describe("serializeToYaml", () => {
       expect(editableSection).not.toContain("created_at:");
       expect(editableSection).not.toContain("timestamp:");
     });
+
+    // `ref deprecate` is the only writer for the superseded mark (#108); exposing it here
+    // would let an edit bypass the successor-exists and cycle checks.
+    it("does not expose the superseded mark for editing", () => {
+      const yaml = serializeToYaml([
+        {
+          ...baseItem,
+          custom: {
+            ...baseItem.custom,
+            superseded_by: "660e8400-e29b-41d4-a716-446655440001",
+            superseded_reason: "duplicate",
+            superseded_at: "2026-08-07T00:00:00.000Z",
+          },
+        },
+      ]);
+      const editableSection = yaml.split("# ========================================")[1];
+      expect(editableSection).not.toContain("superseded_by:");
+      expect(editableSection).not.toContain("superseded_reason:");
+      expect(editableSection).not.toContain("superseded_at:");
+    });
   });
 
   describe("field transformations", () => {

--- a/src/features/format/show-normalizer.test.ts
+++ b/src/features/format/show-normalizer.test.ts
@@ -260,3 +260,67 @@ describe("normalizeReference", () => {
     });
   });
 });
+
+describe("normalizeReference superseded resolution", () => {
+  const successor = makeItem("Carless2023-yt", {
+    title: "Version of record",
+    custom: { uuid: "uuid-new" },
+  });
+  const superseded = makeItem("Carless2020-yj", {
+    title: "Online first",
+    custom: {
+      uuid: "uuid-old",
+      superseded_by: "uuid-new",
+      superseded_reason: "duplicate",
+      superseded_at: "2026-08-07T00:00:00.000Z",
+    },
+  });
+
+  it("resolves the successor's uuid back to its citation key", () => {
+    const result = normalizeReference(superseded, { allItems: [superseded, successor] });
+
+    expect(result.superseded).toEqual({
+      id: "Carless2023-yt",
+      uuid: "uuid-new",
+      reason: "duplicate",
+      at: "2026-08-07T00:00:00.000Z",
+      cycle: false,
+    });
+  });
+
+  it("reports a null id but keeps the uuid when the pointer dangles", () => {
+    const result = normalizeReference(superseded, { allItems: [superseded] });
+
+    expect(result.superseded?.id).toBeNull();
+    expect(result.superseded?.uuid).toBe("uuid-new");
+  });
+
+  it("follows a chain to the final successor", () => {
+    const middle = makeItem("B", { custom: { uuid: "uuid-new", superseded_by: "uuid-final" } });
+    const final = makeItem("C", { custom: { uuid: "uuid-final" } });
+
+    const result = normalizeReference(superseded, { allItems: [superseded, middle, final] });
+
+    expect(result.superseded?.id).toBe("C");
+  });
+
+  it("flags a cycle", () => {
+    const back = makeItem("B", { custom: { uuid: "uuid-new", superseded_by: "uuid-old" } });
+
+    const result = normalizeReference(superseded, { allItems: [superseded, back] });
+
+    expect(result.superseded?.cycle).toBe(true);
+  });
+
+  it("is null for an unmarked reference", () => {
+    expect(
+      normalizeReference(successor, { allItems: [superseded, successor] }).superseded
+    ).toBeNull();
+  });
+
+  // Callers that do not supply the library (MCP resources, other formatters) get null rather
+  // than a half-resolved pointer they would have to interpret.
+  it("is null when no library is supplied", () => {
+    expect(normalizeReference(superseded).superseded).toBeNull();
+  });
+});

--- a/src/features/format/show-normalizer.ts
+++ b/src/features/format/show-normalizer.ts
@@ -7,6 +7,7 @@
 
 import path from "node:path";
 import type { CslItem } from "../../core/csl-json/types.js";
+import { buildUuidIndex, getSupersededMark, resolveFinalSuccessor } from "../superseded/index.js";
 
 /** Convert OS path separators to POSIX forward slashes for consistent output. */
 function toPosixPath(p: string): string {
@@ -21,6 +22,18 @@ export interface NormalizedFulltext {
 export interface NormalizedAttachment {
   filename: string;
   role: string;
+}
+
+/** Resolved successor pointer (#108). */
+export interface NormalizedSuperseded {
+  /** Citation key of the successor, or null when the pointer dangles */
+  id: string | null;
+  /** uuid the pointer names, kept so a dangling pointer is still traceable */
+  uuid: string;
+  reason: string;
+  at: string | null;
+  /** True when the successor chain loops; the library was edited outside `ref deprecate` */
+  cycle: boolean;
 }
 
 export interface NormalizedReference {
@@ -44,11 +57,18 @@ export interface NormalizedReference {
   modified: string | null;
   fulltext: NormalizedFulltext | null;
   attachments: NormalizedAttachment[] | null;
+  /** Null when the reference is not superseded, or when no library was supplied to resolve against */
+  superseded: NormalizedSuperseded | null;
   raw: CslItem;
 }
 
 export interface NormalizeOptions {
   attachmentsDirectory?: string;
+  /**
+   * The whole library, needed to turn a `superseded_by` uuid back into a citation key.
+   * Omit it and `superseded` stays null.
+   */
+  allItems?: CslItem[];
 }
 
 function formatAuthor(author: {
@@ -113,6 +133,24 @@ function normalizeFileInfo(
   return resolveFulltextAndAttachments(item, options.attachmentsDirectory);
 }
 
+function normalizeSuperseded(
+  item: CslItem,
+  options?: NormalizeOptions
+): NormalizedSuperseded | null {
+  const mark = getSupersededMark(item);
+  if (!mark || !options?.allItems) {
+    return null;
+  }
+  const chain = resolveFinalSuccessor(item, buildUuidIndex(options.allItems));
+  return {
+    id: chain?.target?.id ?? null,
+    uuid: mark.supersededBy,
+    reason: mark.reason,
+    at: mark.at ?? null,
+    cycle: chain?.cycle ?? false,
+  };
+}
+
 export function normalizeReference(item: CslItem, options?: NormalizeOptions): NormalizedReference {
   const custom = item.custom;
   const { fulltext, attachments } = normalizeFileInfo(item, options);
@@ -138,6 +176,7 @@ export function normalizeReference(item: CslItem, options?: NormalizeOptions): N
     modified: custom?.timestamp ?? null,
     fulltext,
     attachments,
+    superseded: normalizeSuperseded(item, options),
     raw: item,
   };
 }

--- a/src/features/format/show-pretty.test.ts
+++ b/src/features/format/show-pretty.test.ts
@@ -154,3 +154,49 @@ describe("formatShowPretty", () => {
     expect(result).not.toContain("Authors:");
   });
 });
+
+describe("formatShowPretty superseded line", () => {
+  it("names the successor directly under the header", () => {
+    const output = formatShowPretty(
+      makeNormalized({
+        id: "Carless2020-yj",
+        title: "Online first",
+        superseded: {
+          id: "Carless2023-yt",
+          uuid: "uuid-new",
+          reason: "duplicate",
+          at: "2026-08-07T00:00:00.000Z",
+          cycle: false,
+        },
+      })
+    );
+    const lines = output.split("\n");
+
+    expect(lines[0]).toBe("[Carless2020-yj] Online first");
+    expect(lines[1]).toBe("  SUPERSEDED by Carless2023-yt (duplicate)");
+  });
+
+  it("names the missing uuid when the pointer dangles", () => {
+    const output = formatShowPretty(
+      makeNormalized({
+        superseded: { id: null, uuid: "uuid-gone", reason: "other", at: null, cycle: false },
+      })
+    );
+
+    expect(output).toContain("SUPERSEDED by <missing: uuid-gone> (other)");
+  });
+
+  it("flags a cycle", () => {
+    const output = formatShowPretty(
+      makeNormalized({
+        superseded: { id: "B", uuid: "uuid-b", reason: "duplicate", at: null, cycle: true },
+      })
+    );
+
+    expect(output).toContain("SUPERSEDED by B (duplicate, superseded chain has a cycle)");
+  });
+
+  it("emits no line for an unmarked reference", () => {
+    expect(formatShowPretty(makeNormalized({ superseded: null }))).not.toContain("SUPERSEDED");
+  });
+});

--- a/src/features/format/show-pretty.ts
+++ b/src/features/format/show-pretty.ts
@@ -57,12 +57,28 @@ function formatAbstract(lines: string[], ref: NormalizedReference): void {
   }
 }
 
+/**
+ * Render the successor pointer directly under the header.
+ *
+ * Deliberately not a `label()` row: someone reading this record needs to know before anything
+ * else that they should be citing something else, and stderr warnings are easy to redirect away.
+ */
+function formatSuperseded(lines: string[], ref: NormalizedReference): void {
+  if (!ref.superseded) return;
+  const successor = ref.superseded.id ?? `<missing: ${ref.superseded.uuid}>`;
+  const reason = ref.superseded.cycle
+    ? `${ref.superseded.reason}, superseded chain has a cycle`
+    : ref.superseded.reason;
+  lines.push(`  SUPERSEDED by ${successor} (${reason})`);
+}
+
 export function formatShowPretty(ref: NormalizedReference): string {
   const lines: string[] = [];
 
   // Header
   const header = ref.title ? `[${ref.id}] ${ref.title}` : `[${ref.id}]`;
   lines.push(header);
+  formatSuperseded(lines, ref);
 
   // Core fields
   lines.push(`${label("Type:")}${ref.type}`);

--- a/src/features/operations/deprecate.test.ts
+++ b/src/features/operations/deprecate.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CslItem } from "../../core/csl-json/types.js";
+import type { ILibrary } from "../../core/library-interface.js";
+import { deprecateReference } from "./deprecate.js";
+
+function item(id: string, uuid: string, custom: Record<string, unknown> = {}): CslItem {
+  return {
+    id,
+    type: "article-journal",
+    title: id,
+    custom: {
+      uuid,
+      created_at: "2026-01-01T00:00:00.000Z",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      ...custom,
+    },
+  };
+}
+
+function mark(uuid: string, reason = "duplicate"): Record<string, unknown> {
+  return {
+    superseded_by: uuid,
+    superseded_reason: reason,
+    superseded_at: "2026-08-07T00:00:00.000Z",
+  };
+}
+
+describe("deprecateReference", () => {
+  let library: ILibrary;
+  let items: CslItem[];
+
+  /** Wire a mock library whose find/getAll/update act on `items`. */
+  function useLibrary(initial: CslItem[]): void {
+    items = initial;
+    library = {
+      find: vi.fn(async (identifier: string, options?: { idType?: string }) =>
+        options?.idType === "uuid"
+          ? items.find((i) => i.custom?.uuid === identifier)
+          : items.find((i) => i.id === identifier)
+      ),
+      getAll: vi.fn(async () => items),
+      update: vi.fn(async (id: string, updates: Partial<CslItem>) => {
+        const index = items.findIndex((i) => i.id === id);
+        if (index === -1) return { updated: false };
+        // Mirror Library.buildUpdatedItem: custom is merged, not replaced.
+        const updated: CslItem = {
+          ...items[index],
+          ...updates,
+          custom: { ...items[index]?.custom, ...updates.custom },
+        } as CslItem;
+        items[index] = updated;
+        return { updated: true, item: updated };
+      }),
+      save: vi.fn(async () => undefined),
+    } as unknown as ILibrary;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("setting a mark", () => {
+    beforeEach(() => {
+      useLibrary([item("A", "uuid-a"), item("B", "uuid-b")]);
+    });
+
+    it("points the reference at its successor's uuid", async () => {
+      const result = await deprecateReference(library, {
+        identifier: "A",
+        target: "B",
+        reason: "duplicate",
+      });
+
+      expect(result.applied).toBe(true);
+      expect(result.item?.custom?.superseded_by).toBe("uuid-b");
+      expect(result.item?.custom?.superseded_reason).toBe("duplicate");
+      expect(result.target?.id).toBe("B");
+      expect(library.save).toHaveBeenCalled();
+    });
+
+    it("stamps superseded_at with an ISO timestamp", async () => {
+      const result = await deprecateReference(library, { identifier: "A", target: "B" });
+
+      expect(result.item?.custom?.superseded_at).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+      );
+    });
+
+    it("defaults the reason to other", async () => {
+      const result = await deprecateReference(library, { identifier: "A", target: "B" });
+
+      expect(result.item?.custom?.superseded_reason).toBe("other");
+    });
+
+    it("resolves both identifiers as uuids when idType is uuid", async () => {
+      const result = await deprecateReference(library, {
+        identifier: "uuid-a",
+        target: "uuid-b",
+        idType: "uuid",
+      });
+
+      expect(result.applied).toBe(true);
+      expect(result.item?.id).toBe("A");
+      expect(result.target?.id).toBe("B");
+    });
+
+    it("overwrites an existing mark", async () => {
+      useLibrary([item("A", "uuid-a", mark("uuid-b")), item("B", "uuid-b"), item("C", "uuid-c")]);
+
+      const result = await deprecateReference(library, {
+        identifier: "A",
+        target: "C",
+        reason: "published_version",
+      });
+
+      expect(result.item?.custom?.superseded_by).toBe("uuid-c");
+      expect(result.item?.custom?.superseded_reason).toBe("published_version");
+    });
+
+    it("preserves unrelated custom fields", async () => {
+      useLibrary([item("A", "uuid-a", { tags: ["keep"] }), item("B", "uuid-b")]);
+
+      const result = await deprecateReference(library, { identifier: "A", target: "B" });
+
+      expect(result.item?.custom?.tags).toEqual(["keep"]);
+      expect(result.item?.custom?.uuid).toBe("uuid-a");
+    });
+  });
+
+  describe("validation", () => {
+    beforeEach(() => {
+      useLibrary([item("A", "uuid-a"), item("B", "uuid-b")]);
+    });
+
+    it("rejects an unknown reference", async () => {
+      const result = await deprecateReference(library, { identifier: "missing", target: "B" });
+
+      expect(result).toEqual({ applied: false, errorType: "not_found" });
+      expect(library.save).not.toHaveBeenCalled();
+    });
+
+    it("rejects an unknown successor", async () => {
+      const result = await deprecateReference(library, { identifier: "A", target: "missing" });
+
+      expect(result.applied).toBe(false);
+      expect(result.errorType).toBe("target_not_found");
+      expect(library.save).not.toHaveBeenCalled();
+    });
+
+    it("rejects a self-reference", async () => {
+      const result = await deprecateReference(library, { identifier: "A", target: "A" });
+
+      expect(result.applied).toBe(false);
+      expect(result.errorType).toBe("self_reference");
+      expect(library.save).not.toHaveBeenCalled();
+    });
+
+    it("rejects a successor with no uuid", async () => {
+      useLibrary([item("A", "uuid-a"), { id: "B", type: "article-journal" }]);
+
+      const result = await deprecateReference(library, { identifier: "A", target: "B" });
+
+      expect(result.applied).toBe(false);
+      expect(result.errorType).toBe("target_has_no_uuid");
+    });
+
+    // B is already superseded by A, so pointing A at B would make the pair unciteable.
+    it("rejects a two-record cycle", async () => {
+      useLibrary([item("A", "uuid-a"), item("B", "uuid-b", mark("uuid-a"))]);
+
+      const result = await deprecateReference(library, { identifier: "A", target: "B" });
+
+      expect(result.applied).toBe(false);
+      expect(result.errorType).toBe("cycle");
+      expect(library.save).not.toHaveBeenCalled();
+    });
+
+    it("rejects a longer cycle", async () => {
+      useLibrary([
+        item("A", "uuid-a"),
+        item("B", "uuid-b", mark("uuid-c")),
+        item("C", "uuid-c", mark("uuid-a")),
+      ]);
+
+      const result = await deprecateReference(library, { identifier: "A", target: "B" });
+
+      expect(result.applied).toBe(false);
+      expect(result.errorType).toBe("cycle");
+    });
+
+    it("allows pointing at a record that is itself superseded by an unrelated one", async () => {
+      useLibrary([item("A", "uuid-a"), item("B", "uuid-b", mark("uuid-c")), item("C", "uuid-c")]);
+
+      const result = await deprecateReference(library, { identifier: "A", target: "B" });
+
+      expect(result.applied).toBe(true);
+      expect(result.item?.custom?.superseded_by).toBe("uuid-b");
+    });
+  });
+
+  describe("clearing a mark", () => {
+    it("removes all three fields", async () => {
+      useLibrary([item("A", "uuid-a", mark("uuid-b")), item("B", "uuid-b")]);
+
+      const result = await deprecateReference(library, { identifier: "A", unset: true });
+
+      expect(result.applied).toBe(true);
+      expect(result.item?.custom?.superseded_by).toBeUndefined();
+      expect(result.item?.custom?.superseded_reason).toBeUndefined();
+      expect(result.item?.custom?.superseded_at).toBeUndefined();
+      expect(library.save).toHaveBeenCalled();
+    });
+
+    it("preserves unrelated custom fields", async () => {
+      useLibrary([item("A", "uuid-a", { ...mark("uuid-b"), tags: ["keep"] }), item("B", "uuid-b")]);
+
+      const result = await deprecateReference(library, { identifier: "A", unset: true });
+
+      expect(result.item?.custom?.tags).toEqual(["keep"]);
+      expect(result.item?.custom?.uuid).toBe("uuid-a");
+    });
+
+    it("is a no-op on an unmarked reference", async () => {
+      useLibrary([item("A", "uuid-a")]);
+
+      const result = await deprecateReference(library, { identifier: "A", unset: true });
+
+      expect(result.applied).toBe(false);
+      expect(result.noop).toBe(true);
+      expect(library.save).not.toHaveBeenCalled();
+    });
+
+    it("rejects an unknown reference", async () => {
+      useLibrary([item("A", "uuid-a")]);
+
+      const result = await deprecateReference(library, { identifier: "missing", unset: true });
+
+      expect(result.errorType).toBe("not_found");
+    });
+  });
+});

--- a/src/features/operations/deprecate.ts
+++ b/src/features/operations/deprecate.ts
@@ -1,0 +1,173 @@
+import type { CslItem, SupersededReason } from "../../core/csl-json/types.js";
+import type { ILibrary, IdentifierType } from "../../core/library-interface.js";
+import { buildUuidIndex, getSupersededMark } from "../superseded/index.js";
+
+/**
+ * Options for the deprecateReference operation.
+ *
+ * Exactly one of `target` / `unset` is meaningful: `target` sets the mark, `unset` clears it.
+ * The CLI rejects the ambiguous combinations before calling.
+ */
+export interface DeprecateOperationOptions {
+  /** Reference to mark (or unmark) */
+  identifier: string;
+  /** Identifier type: 'id' (default), 'uuid', 'doi', 'pmid', or 'isbn' */
+  idType?: IdentifierType;
+  /** Successor identifier, resolved with the same idType */
+  target?: string;
+  /** Reason recorded in custom.superseded_reason (default: 'other') */
+  reason?: SupersededReason;
+  /** Clear the mark instead of setting it */
+  unset?: boolean;
+}
+
+export type DeprecateErrorType =
+  | "not_found"
+  | "target_not_found"
+  | "target_has_no_uuid"
+  | "self_reference"
+  | "cycle";
+
+/**
+ * Result of the deprecateReference operation.
+ */
+export interface DeprecateResult {
+  /** Whether the library was changed */
+  applied: boolean;
+  /** The reference after the change (present whenever it was found) */
+  item?: CslItem;
+  /** The successor the mark points at (set operations only) */
+  target?: CslItem;
+  /** True when --unset ran against a reference that carried no mark */
+  noop?: boolean;
+  /** Error type when the operation was rejected */
+  errorType?: DeprecateErrorType;
+}
+
+/**
+ * Whether marking `item` as superseded by `target` would close a loop.
+ *
+ * Walks the successor chain starting at `target`; a chain that reaches `item` means citing the
+ * successor would send the reader back to the record they started from. Also terminates on a
+ * pre-existing cycle elsewhere in the chain.
+ */
+function wouldCreateCycle(item: CslItem, target: CslItem, index: Map<string, CslItem>): boolean {
+  const itemUuid = item.custom?.uuid;
+  if (!itemUuid) {
+    return false;
+  }
+
+  const visited = new Set<string>();
+  let current: CslItem | undefined = target;
+
+  while (current) {
+    const uuid = current.custom?.uuid;
+    if (uuid === itemUuid) {
+      return true;
+    }
+    if (uuid) {
+      if (visited.has(uuid)) {
+        return false;
+      }
+      visited.add(uuid);
+    }
+
+    const mark = getSupersededMark(current);
+    current = mark ? index.get(mark.supersededBy) : undefined;
+  }
+
+  return false;
+}
+
+/**
+ * Clear the superseded mark from a reference.
+ *
+ * The three fields are set to `undefined` rather than omitted: `Library.update` merges `custom`
+ * into the existing object, so an omitted key would leave the old value in place. `undefined`
+ * values are dropped when the library is serialized.
+ */
+async function clearMark(library: ILibrary, item: CslItem): Promise<DeprecateResult> {
+  if (!getSupersededMark(item)) {
+    return { applied: false, item, noop: true };
+  }
+
+  const updateResult = await library.update(
+    item.id,
+    {
+      custom: {
+        ...item.custom,
+        superseded_by: undefined,
+        superseded_reason: undefined,
+        superseded_at: undefined,
+      },
+    },
+    { idType: "id" }
+  );
+  await library.save();
+
+  return { applied: true, item: updateResult.item ?? item };
+}
+
+/**
+ * Mark a reference as superseded by another, or clear an existing mark.
+ *
+ * @param library - The library to modify
+ * @param options - Identifier, successor, and reason
+ * @returns Result carrying the changed reference, or the reason it was rejected
+ */
+export async function deprecateReference(
+  library: ILibrary,
+  options: DeprecateOperationOptions
+): Promise<DeprecateResult> {
+  const { identifier, idType = "id", target, reason = "other", unset = false } = options;
+
+  const item = await library.find(identifier, { idType });
+  if (!item) {
+    return { applied: false, errorType: "not_found" };
+  }
+
+  if (unset) {
+    return clearMark(library, item);
+  }
+
+  if (!target) {
+    return { applied: false, item, errorType: "target_not_found" };
+  }
+
+  const targetItem = await library.find(target, { idType });
+  if (!targetItem) {
+    return { applied: false, item, errorType: "target_not_found" };
+  }
+
+  const targetUuid = targetItem.custom?.uuid;
+  if (!targetUuid) {
+    // Nothing stable to point at. Reachable only for records imported without a uuid, which
+    // ensureCustomMetadata normally backfills.
+    return { applied: false, item, target: targetItem, errorType: "target_has_no_uuid" };
+  }
+
+  if (targetUuid === item.custom?.uuid) {
+    return { applied: false, item, target: targetItem, errorType: "self_reference" };
+  }
+
+  const index = buildUuidIndex(await library.getAll());
+  if (wouldCreateCycle(item, targetItem, index)) {
+    return { applied: false, item, target: targetItem, errorType: "cycle" };
+  }
+
+  const updateResult = await library.update(
+    item.id,
+    {
+      custom: {
+        ...item.custom,
+        superseded_by: targetUuid,
+        superseded_reason: reason,
+        superseded_at: new Date().toISOString(),
+      },
+    },
+    { idType: "id" }
+  );
+  await library.save();
+
+  return { applied: true, item: updateResult.item ?? item, target: targetItem };
+}

--- a/src/features/operations/json-output.ts
+++ b/src/features/operations/json-output.ts
@@ -10,6 +10,7 @@ import type { DuplicateType } from "../duplicate/types.js";
 import type { FailureReason } from "../import/importer.js";
 import type { AddReferencesResult } from "./add.js";
 import { getChangedFields } from "./change-details.js";
+import type { DeprecateErrorType, DeprecateResult } from "./deprecate.js";
 import type { RemoveResult } from "./remove.js";
 import type { UpdateOperationResult } from "./update.js";
 
@@ -298,4 +299,112 @@ export function formatUpdateJsonOutput(
 
   // Handle success case
   return formatUpdateSuccessJson(result, originalId, options);
+}
+
+// ============================================================================
+// Deprecate command types
+// ============================================================================
+
+export interface DeprecateSuccessorJson {
+  id: string;
+  uuid: string;
+}
+
+export interface DeprecateJsonOutput {
+  success: boolean;
+  id: string;
+  uuid?: string;
+  title?: string;
+  /** Present when a mark was set */
+  supersededBy?: DeprecateSuccessorJson;
+  reason?: string;
+  supersededAt?: string;
+  /** True when the mark was cleared */
+  cleared?: boolean;
+  /** True when --unset ran against a reference that carried no mark */
+  unchanged?: boolean;
+  item?: CslItem;
+  error?: string;
+}
+
+export interface FormatDeprecateJsonOptions {
+  /** Include full CSL-JSON data */
+  full?: boolean;
+}
+
+/**
+ * Human-readable message for a rejected deprecate operation.
+ *
+ * Shared by the text and JSON formatters so the two cannot drift.
+ */
+export function describeDeprecateError(
+  errorType: DeprecateErrorType,
+  id: string,
+  target: string | undefined
+): string {
+  switch (errorType) {
+    case "not_found":
+      return `Reference not found: ${id}`;
+    case "target_not_found":
+      return target
+        ? `Successor not found: ${target}`
+        : "No successor given. Use --to <id> or --unset.";
+    case "target_has_no_uuid":
+      return `Successor ${target} has no uuid to point at`;
+    case "self_reference":
+      return `Cannot supersede ${id} by itself`;
+    case "cycle":
+      return `Cannot supersede ${id} by ${target}: ${target} already leads back to ${id}`;
+  }
+}
+
+/**
+ * Format deprecate command result as JSON output
+ */
+export function formatDeprecateJsonOutput(
+  result: DeprecateResult,
+  id: string,
+  target: string | undefined,
+  options: FormatDeprecateJsonOptions = {}
+): DeprecateJsonOutput {
+  const { full = false } = options;
+
+  if (result.errorType) {
+    return {
+      success: false,
+      id,
+      error: describeDeprecateError(result.errorType, id, target),
+    };
+  }
+
+  const item = result.item;
+  const output: DeprecateJsonOutput = {
+    success: true,
+    id: item?.id ?? id,
+    ...(item?.custom?.uuid && { uuid: item.custom.uuid }),
+    ...(typeof item?.title === "string" && { title: item.title }),
+  };
+
+  if (result.noop) {
+    output.unchanged = true;
+  } else if (result.target) {
+    output.supersededBy = {
+      id: result.target.id,
+      uuid: result.target.custom?.uuid ?? "",
+    };
+    if (item?.custom?.superseded_reason) {
+      output.reason = item.custom.superseded_reason;
+    }
+    if (item?.custom?.superseded_at) {
+      output.supersededAt = item.custom.superseded_at;
+    }
+  } else {
+    output.cleared = true;
+  }
+
+  if (full && item) {
+    output.item = item;
+  }
+
+  return output;
 }

--- a/src/features/operations/list.test.ts
+++ b/src/features/operations/list.test.ts
@@ -83,3 +83,62 @@ describe("listReferences", () => {
     });
   });
 });
+
+describe("listReferences superseded filtering", () => {
+  const active: CslItem = {
+    id: "Carless2023-yt",
+    type: "article-journal",
+    title: "Version of record",
+    custom: { uuid: "uuid-new" },
+  };
+  const superseded: CslItem = {
+    id: "Carless2020-yj",
+    type: "article-journal",
+    title: "Online first",
+    custom: {
+      uuid: "uuid-old",
+      superseded_by: "uuid-new",
+      superseded_reason: "duplicate",
+      superseded_at: "2026-08-07T00:00:00.000Z",
+    },
+  };
+
+  function libraryWith(items: CslItem[]): Library {
+    return { getAll: vi.fn().mockResolvedValue(items) } as unknown as Library;
+  }
+
+  it("hides superseded references by default", async () => {
+    const result = await listReferences(libraryWith([active, superseded]), {});
+
+    expect(result.items.map((i) => i.id)).toEqual(["Carless2023-yt"]);
+  });
+
+  it("includes them with includeSuperseded", async () => {
+    const result = await listReferences(libraryWith([active, superseded]), {
+      includeSuperseded: true,
+    });
+
+    expect(result.items.map((i) => i.id).sort()).toEqual(["Carless2020-yj", "Carless2023-yt"]);
+  });
+
+  // `total` drives pagination hints, so it has to describe the filtered set rather than the
+  // raw library size — otherwise `--offset` would page past the end.
+  it("counts only visible references in total", async () => {
+    const hidden = await listReferences(libraryWith([active, superseded]), {});
+    const shown = await listReferences(libraryWith([active, superseded]), {
+      includeSuperseded: true,
+    });
+
+    expect(hidden.total).toBe(1);
+    expect(shown.total).toBe(2);
+  });
+
+  it("paginates over the filtered set", async () => {
+    const items = [active, superseded, { ...active, id: "Other", custom: { uuid: "uuid-3" } }];
+
+    const result = await listReferences(libraryWith(items), { limit: 2 });
+
+    expect(result.items).toHaveLength(2);
+    expect(result.items.every((i) => i.custom?.superseded_by === undefined)).toBe(true);
+  });
+});

--- a/src/features/operations/list.ts
+++ b/src/features/operations/list.ts
@@ -8,11 +8,18 @@ import {
   paginate,
   sortReferences,
 } from "../pagination/index.js";
+import { isSuperseded } from "../superseded/index.js";
 
 /**
  * Options for listReferences operation
  */
-export interface ListOptions extends PaginationOptions, SortOptions {}
+export interface ListOptions extends PaginationOptions, SortOptions {
+  /**
+   * Include references marked as superseded (#108). They are hidden by default: once a
+   * successor exists, the old record is noise in a browsing command.
+   */
+  includeSuperseded?: boolean;
+}
 
 /**
  * Result of listReferences operation
@@ -45,10 +52,13 @@ export async function listReferences(library: ILibrary, options: ListOptions): P
 
   // Get all items
   const allItems = await library.getAll();
-  const total = allItems.length;
+
+  // Filter before counting, so `total` describes what the caller can actually page through
+  const visible = options.includeSuperseded ? allItems : allItems.filter((i) => !isSuperseded(i));
+  const total = visible.length;
 
   // Sort
-  const sorted = sortReferences(allItems, sort, order);
+  const sorted = sortReferences(visible, sort, order);
 
   // Paginate
   const { items: paginatedItems, nextOffset } = paginate(sorted, { limit, offset });

--- a/src/features/superseded/index.ts
+++ b/src/features/superseded/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Superseded reference exports (#108)
+ */
+
+export type { ChainResolution, SupersededMark, SuccessorResolution } from "./resolver.js";
+export {
+  buildUuidIndex,
+  getSupersededMark,
+  isSuperseded,
+  resolveFinalSuccessor,
+  resolveSuccessor,
+} from "./resolver.js";
+export { collectSupersededWarnings, formatSupersededWarning } from "./warning.js";

--- a/src/features/superseded/resolver.test.ts
+++ b/src/features/superseded/resolver.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import type { CslItem } from "../../core/csl-json/types.js";
+import {
+  buildUuidIndex,
+  getSupersededMark,
+  isSuperseded,
+  resolveFinalSuccessor,
+  resolveSuccessor,
+} from "./resolver.js";
+
+function item(id: string, uuid: string, custom: Record<string, unknown> = {}): CslItem {
+  return {
+    id,
+    type: "article-journal",
+    title: id,
+    custom: {
+      uuid,
+      created_at: "2026-01-01T00:00:00.000Z",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      ...custom,
+    },
+  };
+}
+
+function mark(uuid: string, reason = "duplicate"): Record<string, unknown> {
+  return {
+    superseded_by: uuid,
+    superseded_reason: reason,
+    superseded_at: "2026-08-07T00:00:00.000Z",
+  };
+}
+
+describe("getSupersededMark", () => {
+  it("returns the mark when superseded_by is present", () => {
+    expect(getSupersededMark(item("A", "uuid-a", mark("uuid-b")))).toEqual({
+      supersededBy: "uuid-b",
+      reason: "duplicate",
+      at: "2026-08-07T00:00:00.000Z",
+    });
+  });
+
+  it("returns null for an unmarked reference", () => {
+    expect(getSupersededMark(item("A", "uuid-a"))).toBeNull();
+  });
+
+  it("returns null when the item has no custom block", () => {
+    expect(getSupersededMark({ id: "A", type: "article-journal" })).toBeNull();
+  });
+
+  // Hand-edited or foreign data may carry only the pointer. The pointer is the part that
+  // matters, so it is honoured; the descriptive fields fall back.
+  it("defaults a missing reason to other", () => {
+    expect(getSupersededMark(item("A", "uuid-a", { superseded_by: "uuid-b" }))).toEqual({
+      supersededBy: "uuid-b",
+      reason: "other",
+      at: undefined,
+    });
+  });
+
+  it("treats an empty superseded_by as unmarked", () => {
+    expect(getSupersededMark(item("A", "uuid-a", { superseded_by: "" }))).toBeNull();
+    expect(getSupersededMark(item("A", "uuid-a", { superseded_by: "   " }))).toBeNull();
+  });
+
+  it("ignores a reason or timestamp without a pointer", () => {
+    expect(
+      getSupersededMark(item("A", "uuid-a", { superseded_reason: "duplicate", superseded_at: "x" }))
+    ).toBeNull();
+  });
+});
+
+describe("isSuperseded", () => {
+  it("reflects the presence of a pointer", () => {
+    expect(isSuperseded(item("A", "uuid-a", mark("uuid-b")))).toBe(true);
+    expect(isSuperseded(item("A", "uuid-a"))).toBe(false);
+  });
+});
+
+describe("buildUuidIndex", () => {
+  it("indexes items by uuid", () => {
+    const a = item("A", "uuid-a");
+    const b = item("B", "uuid-b");
+    const index = buildUuidIndex([a, b]);
+    expect(index.get("uuid-a")).toBe(a);
+    expect(index.get("uuid-b")).toBe(b);
+  });
+
+  it("skips items without a uuid", () => {
+    const index = buildUuidIndex([{ id: "A", type: "article-journal" }]);
+    expect(index.size).toBe(0);
+  });
+});
+
+describe("resolveSuccessor", () => {
+  const a = item("A", "uuid-a", mark("uuid-b"));
+  const b = item("B", "uuid-b");
+
+  it("returns the successor", () => {
+    expect(resolveSuccessor(a, buildUuidIndex([a, b]))).toEqual({ target: b, dangling: false });
+  });
+
+  it("reports a dangling pointer when the uuid is absent", () => {
+    expect(resolveSuccessor(a, buildUuidIndex([a]))).toEqual({ target: null, dangling: true });
+  });
+
+  it("returns null for an unmarked reference", () => {
+    expect(resolveSuccessor(b, buildUuidIndex([a, b]))).toBeNull();
+  });
+});
+
+describe("resolveFinalSuccessor", () => {
+  it("follows a single hop", () => {
+    const a = item("A", "uuid-a", mark("uuid-b"));
+    const b = item("B", "uuid-b");
+    expect(resolveFinalSuccessor(a, buildUuidIndex([a, b]))).toEqual({
+      target: b,
+      dangling: false,
+      cycle: false,
+      hops: 1,
+    });
+  });
+
+  it("follows a chain to its end", () => {
+    const a = item("A", "uuid-a", mark("uuid-b"));
+    const b = item("B", "uuid-b", mark("uuid-c"));
+    const c = item("C", "uuid-c");
+    expect(resolveFinalSuccessor(a, buildUuidIndex([a, b, c]))).toEqual({
+      target: c,
+      dangling: false,
+      cycle: false,
+      hops: 2,
+    });
+  });
+
+  it("reports the last resolvable record when the chain dangles", () => {
+    const a = item("A", "uuid-a", mark("uuid-b"));
+    const b = item("B", "uuid-b", mark("uuid-missing"));
+    expect(resolveFinalSuccessor(a, buildUuidIndex([a, b]))).toEqual({
+      target: b,
+      dangling: true,
+      cycle: false,
+      hops: 1,
+    });
+  });
+
+  it("reports a dangling first hop with no target", () => {
+    const a = item("A", "uuid-a", mark("uuid-missing"));
+    expect(resolveFinalSuccessor(a, buildUuidIndex([a]))).toEqual({
+      target: null,
+      dangling: true,
+      cycle: false,
+      hops: 0,
+    });
+  });
+
+  // `ref deprecate` rejects cycles, but a hand-edited library.json can still contain one and
+  // must not hang the CLI.
+  it("terminates on a two-record cycle", () => {
+    const a = item("A", "uuid-a", mark("uuid-b"));
+    const b = item("B", "uuid-b", mark("uuid-a"));
+    const result = resolveFinalSuccessor(a, buildUuidIndex([a, b]));
+    expect(result?.cycle).toBe(true);
+    expect(result?.target).toBe(b);
+  });
+
+  it("terminates on a self-reference", () => {
+    const a = item("A", "uuid-a", mark("uuid-a"));
+    const result = resolveFinalSuccessor(a, buildUuidIndex([a]));
+    expect(result?.cycle).toBe(true);
+  });
+
+  it("terminates on a longer cycle", () => {
+    const a = item("A", "uuid-a", mark("uuid-b"));
+    const b = item("B", "uuid-b", mark("uuid-c"));
+    const c = item("C", "uuid-c", mark("uuid-a"));
+    const result = resolveFinalSuccessor(a, buildUuidIndex([a, b, c]));
+    expect(result?.cycle).toBe(true);
+    expect(result?.target).toBe(c);
+  });
+
+  it("returns null for an unmarked reference", () => {
+    const a = item("A", "uuid-a");
+    expect(resolveFinalSuccessor(a, buildUuidIndex([a]))).toBeNull();
+  });
+});

--- a/src/features/superseded/resolver.ts
+++ b/src/features/superseded/resolver.ts
@@ -1,0 +1,152 @@
+/**
+ * Superseded pointer resolution (#108).
+ *
+ * `custom.superseded_by` holds the successor's uuid, so resolving a pointer means a lookup
+ * against a uuid index. Callers build the index once per command and reuse it — a library of
+ * several thousand references makes a per-item linear scan quadratic.
+ *
+ * See spec/features/superseded.md.
+ */
+
+import type { CslItem } from "../../core/csl-json/types.js";
+
+/** A superseded mark read off a reference. */
+export interface SupersededMark {
+  /** uuid of the successor. Never empty. */
+  supersededBy: string;
+  /** Free string from storage; falls back to "other" when absent. */
+  reason: string;
+  /** ISO 8601 timestamp, absent on hand-written marks. */
+  at: string | undefined;
+}
+
+/** Result of following a single `superseded_by` pointer. */
+export interface SuccessorResolution {
+  /** The successor, or null when its uuid is absent from the library. */
+  target: CslItem | null;
+  /** True when the pointer names a uuid that is not in the library. */
+  dangling: boolean;
+}
+
+/** Result of following a `superseded_by` chain to its end. */
+export interface ChainResolution {
+  /** Last record reached, or null when the very first hop dangled. */
+  target: CslItem | null;
+  /** True when the chain ended at a pointer whose uuid is absent from the library. */
+  dangling: boolean;
+  /** True when the chain revisited a record; `target` is the last one reached before that. */
+  cycle: boolean;
+  /** Number of pointers successfully followed. */
+  hops: number;
+}
+
+/** Reason recorded when a mark carries a pointer but no reason. */
+const DEFAULT_REASON = "other";
+
+/**
+ * Read the superseded mark off a reference.
+ *
+ * The pointer alone constitutes a mark: `ref deprecate` always writes all three fields, but a
+ * hand-edited or externally written record may carry only `superseded_by`, and dropping such a
+ * pointer would silently lose the one piece of information that matters.
+ *
+ * @returns The mark, or null when the reference carries no usable pointer
+ */
+export function getSupersededMark(item: CslItem): SupersededMark | null {
+  const supersededBy = item.custom?.superseded_by?.trim();
+  if (!supersededBy) {
+    return null;
+  }
+  return {
+    supersededBy,
+    reason: item.custom?.superseded_reason?.trim() || DEFAULT_REASON,
+    at: item.custom?.superseded_at,
+  };
+}
+
+/** Whether a reference carries a superseded pointer. */
+export function isSuperseded(item: CslItem): boolean {
+  return getSupersededMark(item) !== null;
+}
+
+/**
+ * Index references by uuid for pointer resolution.
+ * References without a uuid cannot be pointed at and are skipped.
+ */
+export function buildUuidIndex(items: CslItem[]): Map<string, CslItem> {
+  const index = new Map<string, CslItem>();
+  for (const item of items) {
+    const uuid = item.custom?.uuid;
+    if (uuid) {
+      index.set(uuid, item);
+    }
+  }
+  return index;
+}
+
+/**
+ * Follow one `superseded_by` pointer.
+ *
+ * @returns The resolution, or null when the reference is not superseded
+ */
+export function resolveSuccessor(
+  item: CslItem,
+  index: Map<string, CslItem>
+): SuccessorResolution | null {
+  const mark = getSupersededMark(item);
+  if (!mark) {
+    return null;
+  }
+  const target = index.get(mark.supersededBy);
+  return target ? { target, dangling: false } : { target: null, dangling: true };
+}
+
+/**
+ * Follow a `superseded_by` chain to the last reachable record.
+ *
+ * `ref deprecate` rejects cycles, so a cycle here means the library was edited by hand or by
+ * another tool. Detect and report it rather than looping.
+ *
+ * @returns The resolution, or null when the reference is not superseded
+ */
+export function resolveFinalSuccessor(
+  item: CslItem,
+  index: Map<string, CslItem>
+): ChainResolution | null {
+  if (!isSuperseded(item)) {
+    return null;
+  }
+
+  const visited = new Set<string>();
+  const startUuid = item.custom?.uuid;
+  if (startUuid) {
+    visited.add(startUuid);
+  }
+
+  let current = item;
+  let target: CslItem | null = null;
+  let hops = 0;
+
+  while (true) {
+    const mark = getSupersededMark(current);
+    if (!mark) {
+      // Chain ended at a record that is not itself superseded.
+      return { target, dangling: false, cycle: false, hops };
+    }
+
+    const next = index.get(mark.supersededBy);
+    if (!next) {
+      return { target, dangling: true, cycle: false, hops };
+    }
+    if (visited.has(mark.supersededBy)) {
+      // Report the last record reached before the chain looped back. Returning the repeated
+      // record would name something the caller has already been told about.
+      return { target, dangling: false, cycle: true, hops };
+    }
+
+    visited.add(mark.supersededBy);
+    target = next;
+    current = next;
+    hops += 1;
+  }
+}

--- a/src/features/superseded/warning.test.ts
+++ b/src/features/superseded/warning.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import type { CslItem } from "../../core/csl-json/types.js";
+import { buildUuidIndex } from "./resolver.js";
+import { collectSupersededWarnings, formatSupersededWarning } from "./warning.js";
+
+function item(id: string, uuid: string, custom: Record<string, unknown> = {}): CslItem {
+  return {
+    id,
+    type: "article-journal",
+    title: id,
+    custom: {
+      uuid,
+      created_at: "2026-01-01T00:00:00.000Z",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      ...custom,
+    },
+  };
+}
+
+function mark(uuid: string, reason = "duplicate"): Record<string, unknown> {
+  return {
+    superseded_by: uuid,
+    superseded_reason: reason,
+    superseded_at: "2026-08-07T00:00:00.000Z",
+  };
+}
+
+describe("formatSupersededWarning", () => {
+  it("names the successor by citation key", () => {
+    const a = item("Carless2020-yj", "uuid-a", mark("uuid-b"));
+    const b = item("Carless2023-yt", "uuid-b");
+    expect(formatSupersededWarning(a, buildUuidIndex([a, b]))).toBe(
+      "[SUPERSEDED] Carless2020-yj -> Carless2023-yt (duplicate)"
+    );
+  });
+
+  it("resolves through a chain to the final successor", () => {
+    const a = item("A", "uuid-a", mark("uuid-b"));
+    const b = item("B", "uuid-b", mark("uuid-c", "published_version"));
+    const c = item("C", "uuid-c");
+    // The reason shown is the starting record's own reason, not the intermediate one.
+    expect(formatSupersededWarning(a, buildUuidIndex([a, b, c]))).toBe(
+      "[SUPERSEDED] A -> C (duplicate)"
+    );
+  });
+
+  it("names the missing uuid when the pointer dangles", () => {
+    const a = item("A", "uuid-a", mark("uuid-gone"));
+    expect(formatSupersededWarning(a, buildUuidIndex([a]))).toBe(
+      "[SUPERSEDED] A -> <missing: uuid-gone> (duplicate)"
+    );
+  });
+
+  it("flags a cycle rather than presenting the chain as resolved", () => {
+    const a = item("A", "uuid-a", mark("uuid-b"));
+    const b = item("B", "uuid-b", mark("uuid-a"));
+    expect(formatSupersededWarning(a, buildUuidIndex([a, b]))).toBe(
+      "[SUPERSEDED] A -> B (duplicate, superseded chain has a cycle)"
+    );
+  });
+
+  it("falls back to the reason default on a pointer-only mark", () => {
+    const a = item("A", "uuid-a", { superseded_by: "uuid-b" });
+    const b = item("B", "uuid-b");
+    expect(formatSupersededWarning(a, buildUuidIndex([a, b]))).toBe("[SUPERSEDED] A -> B (other)");
+  });
+
+  it("returns null for an unmarked reference", () => {
+    const a = item("A", "uuid-a");
+    expect(formatSupersededWarning(a, buildUuidIndex([a]))).toBeNull();
+  });
+});
+
+describe("collectSupersededWarnings", () => {
+  const a = item("A", "uuid-a", mark("uuid-c"));
+  const b = item("B", "uuid-b");
+  const c = item("C", "uuid-c");
+
+  it("returns one line per superseded reference, in input order", () => {
+    expect(collectSupersededWarnings([a, b, c], [a, b, c])).toEqual([
+      "[SUPERSEDED] A -> C (duplicate)",
+    ]);
+  });
+
+  it("returns an empty array when nothing is superseded", () => {
+    expect(collectSupersededWarnings([b, c], [a, b, c])).toEqual([]);
+  });
+
+  // The successor may sit outside the shown subset — resolution must use the whole library.
+  it("resolves against the full library, not just the shown items", () => {
+    expect(collectSupersededWarnings([a], [a, b, c])).toEqual(["[SUPERSEDED] A -> C (duplicate)"]);
+  });
+});

--- a/src/features/superseded/warning.ts
+++ b/src/features/superseded/warning.ts
@@ -1,0 +1,50 @@
+/**
+ * Warning lines for superseded references (#108).
+ *
+ * These always go to stderr. stdout stays byte-identical to the unmarked case so that piping
+ * `ref export`, `ref cite`, or `ref list --output ids` into another tool keeps working.
+ *
+ * See spec/features/superseded.md.
+ */
+
+import type { CslItem } from "../../core/csl-json/types.js";
+import { buildUuidIndex, getSupersededMark, resolveFinalSuccessor } from "./resolver.js";
+
+/**
+ * Build the stderr warning line for one reference.
+ *
+ * @returns The line, or null when the reference is not superseded
+ */
+export function formatSupersededWarning(item: CslItem, index: Map<string, CslItem>): string | null {
+  const mark = getSupersededMark(item);
+  if (!mark) {
+    return null;
+  }
+
+  const chain = resolveFinalSuccessor(item, index);
+  const target = chain?.target;
+  // A dangling first hop leaves no record to name, so show the uuid the pointer asked for —
+  // it is the only handle the user has for tracking down what was removed.
+  const successor = target ? target.id : `<missing: ${mark.supersededBy}>`;
+  const suffix = chain?.cycle ? `${mark.reason}, superseded chain has a cycle` : mark.reason;
+
+  return `[SUPERSEDED] ${item.id} -> ${successor} (${suffix})`;
+}
+
+/**
+ * Build warning lines for every superseded reference among `items`.
+ *
+ * @param items - The references being shown to the user
+ * @param allItems - The whole library; pointers may target records outside `items`
+ */
+export function collectSupersededWarnings(items: CslItem[], allItems: CslItem[]): string[] {
+  const index = buildUuidIndex(allItems);
+  const warnings: string[] = [];
+  for (const item of items) {
+    const warning = formatSupersededWarning(item, index);
+    if (warning) {
+      warnings.push(warning);
+    }
+  }
+  return warnings;
+}

--- a/src/server/routes/list.ts
+++ b/src/server/routes/list.ts
@@ -13,6 +13,7 @@ const listRequestBodySchema = z.object({
   order: sortOrderSchema.optional(),
   limit: z.number().int().min(0).optional(),
   offset: z.number().int().min(0).optional(),
+  includeSuperseded: z.boolean().optional(),
 });
 
 /**

--- a/test-fixtures/test-superseded.sh
+++ b/test-fixtures/test-superseded.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Manual verification for superseded pointers and the deprecate command (#108).
+# Usage: ./test-fixtures/test-superseded.sh
+#
+# Run `npm run build` first — this exercises the built CLI, not the sources.
+
+CLI="${CLI:-node bin/cli.js}"
+PASS=0
+FAIL=0
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+LIB="$TMPDIR/library.json"
+export REFERENCE_MANAGER_LIBRARY="$LIB"
+
+cat > "$LIB" <<'JSON'
+[
+  {"id":"Carless2020-yj","type":"article-journal","title":"Online first version",
+   "DOI":"10.1080/13562517.2020.1782372",
+   "custom":{"uuid":"11111111-1111-4111-8111-111111111111",
+             "created_at":"2026-01-01T00:00:00.000Z","timestamp":"2026-01-01T00:00:00.000Z"}},
+  {"id":"Carless2023-yt","type":"article-journal","title":"Version of record",
+   "DOI":"10.1080/13562517.2020.1782372",
+   "custom":{"uuid":"22222222-2222-4222-8222-222222222222",
+             "created_at":"2026-01-01T00:00:00.000Z","timestamp":"2026-01-01T00:00:00.000Z"}}
+]
+JSON
+
+expect_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"
+    echo "        expected to contain: $needle"
+    echo "        got: $haystack"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+expect_not_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (unexpectedly contained: $needle)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+expect_exit() {
+  local desc="$1" expected="$2"
+  shift 2
+  local actual=0
+  "$@" >/dev/null 2>&1 || actual=$?
+  if [[ "$actual" == "$expected" ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (exit $actual, expected $expected)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "== baseline export (before marking) =="
+BEFORE="$($CLI export --all -o json 2>/dev/null)"
+
+echo "== deprecate =="
+OUT="$($CLI deprecate Carless2020-yj --to Carless2023-yt --reason duplicate 2>&1)"
+expect_contains "reports the mark" "$OUT" "Marked Carless2020-yj as superseded by Carless2023-yt (duplicate)"
+
+STORED="$(node -e "console.log(JSON.stringify(require('$LIB')[0].custom))")"
+expect_contains "stores the successor uuid, not its key" "$STORED" "22222222-2222-4222-8222-222222222222"
+expect_contains "stores the reason" "$STORED" '"superseded_reason":"duplicate"'
+
+echo "== show =="
+OUT="$($CLI show Carless2020-yj 2>&1)"
+expect_contains "pretty output marks the record" "$OUT" "SUPERSEDED by Carless2023-yt (duplicate)"
+OUT="$($CLI show Carless2020-yj 2>&1 >/dev/null)"
+expect_contains "warns on stderr" "$OUT" "[SUPERSEDED] Carless2020-yj -> Carless2023-yt (duplicate)"
+
+echo "== export: included, warned, stdout unchanged =="
+AFTER="$($CLI export --all -o json 2>/dev/null)"
+expect_contains "record is still exported" "$AFTER" "Carless2020-yj"
+ERR="$($CLI export --all -o json 2>&1 >/dev/null)"
+expect_contains "warns per record" "$ERR" "[SUPERSEDED] Carless2020-yj -> Carless2023-yt"
+expect_contains "prints the summary" "$ERR" "1 superseded reference included. Update your manuscript keys."
+# stdout differs only by the mark itself, which lives under custom
+if [[ "$(echo "$BEFORE" | grep -c 'Carless2020-yj')" == "$(echo "$AFTER" | grep -c 'Carless2020-yj')" ]]; then
+  echo "  PASS: stdout still carries the record"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: stdout dropped the record"
+  FAIL=$((FAIL + 1))
+fi
+
+echo "== list =="
+OUT="$($CLI list --ids-only 2>/dev/null)"
+expect_not_contains "hides superseded by default" "$OUT" "Carless2020-yj"
+expect_contains "keeps the successor" "$OUT" "Carless2023-yt"
+OUT="$($CLI list --ids-only --include-superseded 2>/dev/null)"
+expect_contains "--include-superseded shows it" "$OUT" "Carless2020-yj"
+
+echo "== search warns but does not filter =="
+OUT="$($CLI search "Online first" --ids-only 2>/dev/null)"
+expect_contains "result is not filtered out" "$OUT" "Carless2020-yj"
+ERR="$($CLI search "Online first" --ids-only 2>&1 >/dev/null)"
+expect_contains "search warns" "$ERR" "[SUPERSEDED] Carless2020-yj"
+
+echo "== cite warns =="
+ERR="$($CLI cite Carless2020-yj 2>&1 >/dev/null)"
+expect_contains "cite warns" "$ERR" "[SUPERSEDED] Carless2020-yj"
+
+echo "== validation =="
+expect_exit "cycle is rejected" 1 $CLI deprecate Carless2023-yt --to Carless2020-yj
+expect_exit "self-reference is rejected" 1 $CLI deprecate Carless2020-yj --to Carless2020-yj
+expect_exit "--to with --unset is rejected" 1 $CLI deprecate Carless2020-yj --to Carless2023-yt --unset
+expect_exit "unknown reason is rejected" 1 $CLI deprecate Carless2020-yj --to Carless2023-yt --reason merged
+expect_exit "protected field is rejected by update --set" 4 \
+  $CLI update Carless2020-yj --set custom.superseded_by=hack
+
+echo "== unset =="
+OUT="$($CLI deprecate Carless2020-yj --unset 2>&1)"
+expect_contains "reports the clear" "$OUT" "Cleared the superseded mark from Carless2020-yj"
+STORED="$(node -e "console.log(JSON.stringify(require('$LIB')[0].custom))")"
+expect_not_contains "superseded_by is gone" "$STORED" "superseded_by"
+expect_not_contains "superseded_reason is gone" "$STORED" "superseded_reason"
+expect_not_contains "superseded_at is gone" "$STORED" "superseded_at"
+
+OUT="$($CLI deprecate Carless2020-yj --unset 2>&1)"
+expect_contains "second unset is a no-op" "$OUT" "is not marked as superseded"
+
+OUT="$($CLI list --ids-only 2>/dev/null)"
+expect_contains "record is visible again" "$OUT" "Carless2020-yj"
+
+echo
+echo "PASS: $PASS  FAIL: $FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

First of three PRs for #108. Gives the library a way to say "do not cite this one, cite that one" without deleting the redundant record — deleting would leave an unresolvable key in any manuscript that already cites it.

This part covers the data model, the `ref deprecate` command, and reference-time reporting. That is enough to handle the conference-version → journal-version case by hand, which no automatic detector can reach (issue case 3).

**Not in this PR** (hence `Refs #108`, not `Closes`):
- PR-2: `ref duplicates [--by ...] [--fix]` — retroactive DOI/PMID/ISBN/arXiv/ERIC scan (issue case 1, the 36 pairs found in the maintainer's library)
- PR-3: `check --fix` action that adds the published version as a new record and marks the old one (issue case 2)

## Design decisions

**`superseded_by` holds the successor's UUID, not its citation key.** The issue sketched a key-valued pointer, but citation keys are mutable — `resolveNewId` in `src/core/library.ts` renames on collision during `edit`/`update`. A key-valued pointer would dangle silently after an unrelated edit. All output resolves the UUID back to a citation key; the UUID only surfaces when the pointer dangles, where it is the sole remaining handle on what was removed.

**`export` keeps superseded records; `list` hides them.** The issue proposed excluding from `export --all`, but that is where exclusion hurts most: the bibliography build is exactly the place a manuscript still citing the old key would break, and a missing entry surfaces as an unresolved citeproc key rather than a warning. `export` therefore warns and includes. `list` is browsing, where the old record is pure noise, so it hides behind `--include-superseded`. `search` warns without filtering — silently dropping a record the user asked for by name would be surprising.

**`superseded_reason` is a free string in the storage schema.** A strict enum would make a reason written by another tool fail the parse of the entire `library.json`. `ref deprecate` enforces the `duplicate | published_version | other` union at the CLI boundary instead.

**The three fields joined `MANAGED_CUSTOM_FIELDS`, not `PROTECTED_CUSTOM_FIELDS`.** That makes `ref deprecate` their only writer — `update --set custom.superseded_*` is rejected and `edit` restores the originals — which is what keeps the successor-exists and cycle checks meaningful. Staying out of `PROTECTED_CUSTOM_FIELDS` means marking a record still registers as a real change and bumps `custom.timestamp`.

## What's here

```
$ ref deprecate Carless2020-yj --to Carless2023-yt --reason duplicate
Marked Carless2020-yj as superseded by Carless2023-yt (duplicate).

$ ref export --all -o json > refs.json
[SUPERSEDED] Carless2020-yj -> Carless2023-yt (duplicate)
1 superseded reference included. Update your manuscript keys.

$ ref deprecate Carless2023-yt --to Carless2020-yj
Error: Cannot supersede Carless2023-yt by Carless2020-yj: Carless2020-yj already leads back to Carless2023-yt
```

- `src/features/superseded/` — pointer resolution against a prebuilt UUID index, chain following with cycle detection, warning formatting
- `src/features/operations/deprecate.ts` — set/clear with existence, self-reference and cycle validation
- `src/cli/commands/deprecate.ts` — `--to` / `--unset` / `--reason` / `--uuid` / `-o json` / `--full`
- `src/cli/superseded-report.ts` — one shared stderr reporter used by `show`, `cite`, `search`, `export`, `list`

Warnings are stderr-only, so `ref export --all | pandoc`, `ref cite … | pbcopy` and `ref list --output ids | xargs` keep working byte-for-byte. The reporter fetches the library only after finding a marked record among those being shown, so the common (unmarked) case costs nothing.

`includeSuperseded` is forwarded through `ILibraryOperations.list` → `ServerClient` → the `/api/list` request schema, so `--include-superseded` is not silently dropped when a server is running.

Chains are followed to the final successor. `ref deprecate` rejects cycles, but a hand-edited `library.json` can still contain one, so `resolveFinalSuccessor` carries a visited set and reports the cycle instead of hanging.

## Verification

- `npm test` — 187 files, 3684 passed
- `npm run test:e2e` — 3979 passed
- `./test-fixtures/test-superseded.sh` — 26/26 (new script covering the per-command wiring end to end)
- `npm run lint`, `npm run typecheck`, `npm run build` — clean

Two caveats on the numbers:

- The 5 `src/config/loader.test.ts` failures on the maintainer's machine are #105, which this branch predates. PR #109 fixes them; merging it first will make this branch's run clean.
- Two e2e tests (`json-output.e2e.test.ts` idChanged, `interactive-id-selection.e2e.test.ts` non-TTY update) each failed once across two full runs — a *different* one each time, and both pass in isolation. Pre-existing load-dependent flakiness in CLI-spawning e2e tests, unrelated to this change.

Refs #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mau1bJxTcehVb9sWexf8L9