### PR TITLE
feat(check): add published version as a new record and supersede the old (#108, PR-3 of 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `export` keeps the record and adds a summary line naming how many were included
   - Chains are followed to the final successor; a cycle introduced by hand-editing
     `library.json` is reported rather than looped over
-  - This is the first of three parts of #108. Still to come: a `check --fix` action that adds
-    the published version as a new record and marks the old one
+  - Delivered across three PRs: pointers and `ref deprecate` (#110), the `ref duplicates` scan
+    (#112), and the `check --fix` action below
 
 - **Retroactive duplicate scan** (#108): `ref duplicates` applies the `add`-time matching rules
   to the whole library at once. `add` skips duplicates as they arrive but says nothing about
@@ -50,6 +50,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `--fix` requires a TTY, matching `check --fix`: which record to keep is a judgement call.
     The suggestion ranks by metadata completeness, then publication year — the ordering that
     separates an online-first record from its version of record
+
+- **`check --fix` can keep both versions** (#108): `version_changed` findings gain an
+  `add_published_and_supersede` action that adds the published version as a new record and marks
+  the preprint as superseded by it
+  - Listed before the existing in-place update, which silently changes what the preprint's
+    citation key resolves to — a manuscript citing the preprint would render the published
+    article under a key that no longer describes it
+  - Reuses an existing record when the published DOI is already in the library, rather than
+    adding a second copy of it
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -520,6 +520,12 @@ Sources queried:
 
 Use `--fix` to interactively update changed fields from the remote source.
 
+For a preprint whose published version has appeared, `--fix` offers to **add the published version
+as a new record and mark the preprint as superseded by it**. That option is listed first: updating
+the preprint's metadata in place silently changes what its citation key resolves to, so a
+manuscript citing the preprint would render the published article under a key that no longer
+describes it. If the published DOI is already in your library, the existing record is reused.
+
 Results are saved to `custom.check` by default for skip-if-recent logic.
 
 ### Superseded References

--- a/spec/features/superseded.md
+++ b/spec/features/superseded.md
@@ -166,6 +166,25 @@ record, which is the one that gained volume, issue and page numbers.
 Marking goes through the same `deprecate` path, so a stale group cannot write a pointer the
 command itself would have refused.
 
+## `check --fix`: preprint → published
+
+`check` detects `version_changed` from Crossref's `update-to` relation. Its fix actions are:
+
+| Action | Effect |
+|--------|--------|
+| `add_published_and_supersede` | Add the published version as a **new** record, mark this one superseded by it (`published_version`) |
+| `update_from_published` | Overwrite this record's metadata in place, keeping the citation key |
+| `add_version_tag` | Tag `has-published-version` |
+
+`add_published_and_supersede` is listed first. Overwriting in place silently changes what an
+existing citation key resolves to, so a manuscript citing the preprint ends up rendering the
+published article under a key that no longer describes it. Adding the published version alongside
+keeps both records: the old key still resolves, and every read command reports where to cite
+instead.
+
+If the published DOI is already in the library, that record is reused rather than fetched and
+added again — otherwise the fix would create exactly the duplicate this feature exists to resolve.
+
 ## Non-Goals
 
 - No automatic rewriting of citation keys in manuscripts

--- a/spec/tasks/20260807-02-superseded-pointers.md
+++ b/spec/tasks/20260807-02-superseded-pointers.md
@@ -11,7 +11,8 @@ Follow-up PRs:
 
 - PR-2 (done, PR #111): `ref duplicates [--by ...] [--fix]` — retroactive scan, applies marks in
   bulk. See "Step 7" below.
-- PR-3: `check --fix` action that adds the published version as a new record and marks the old one
+- PR-3 (done, PR #113): `check --fix` action that adds the published version as a new record and
+  marks the old one. See "Step 8" below.
 
 ## References
 
@@ -134,6 +135,16 @@ stays clean — is covered end to end by `test-fixtures/test-superseded.sh`.
       convergence checks
 - [x] Update `spec/features/superseded.md`, `spec/_index.md`, README, CHANGELOG
 
+### Step 8: `check --fix` keeps both versions (PR-3)
+
+- [x] Write test: `src/features/check/fix-actions.test.ts` — the action list for `version_changed`
+      now leads with the additive option; applying it adds the record and writes the mark; the
+      fetched id and custom block are dropped; an already-present published DOI is reused; fetch
+      failure and a missing `newDoi` are reported; a record added but not marked says so
+- [x] Add `add_published_and_supersede` to `FixActionType` and `getFixActionsForFinding`
+- [x] Implement `applyAddPublishedAndSupersede` in `src/features/check/fix-actions.ts`
+- [x] Update `spec/features/superseded.md`, README, CHANGELOG
+
 ## Manual Verification
 
 **Script**: `test-fixtures/test-superseded.sh`
@@ -160,4 +171,4 @@ Non-TTY tests (automated):
 - [ ] Manual verification: `./test-fixtures/test-superseded.sh`
 - [ ] CHANGELOG.md updated
 - [ ] PR description references #108 (do **not** close it — PR-2 and PR-3 remain)
-- [ ] Move this file to `spec/tasks/completed/` when all three PRs land
+- [x] Move this file to `spec/tasks/completed/` when all three PRs land

--- a/src/features/check/fix-actions.test.ts
+++ b/src/features/check/fix-actions.test.ts
@@ -37,8 +37,11 @@ describe("getFixActionsForFinding", () => {
 
     const actions = getFixActionsForFinding(finding);
 
-    expect(actions).toHaveLength(3);
+    expect(actions).toHaveLength(4);
+    // The additive option is listed first: overwriting in place changes what the preprint's
+    // citation key resolves to (#108).
     expect(actions.map((a) => a.type)).toEqual([
+      "add_published_and_supersede",
       "update_from_published",
       "add_version_tag",
       "skip",
@@ -700,5 +703,207 @@ describe("applyFixAction", () => {
       expect(mockLibrary.remove).not.toHaveBeenCalled();
       expect(mockLibrary.save).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe("add_published_and_supersede", () => {
+  const preprint: CslItem = {
+    id: "preprint-2024",
+    type: "article-journal",
+    title: "Preprint Title",
+    DOI: "10.1234/preprint",
+    custom: { uuid: "uuid-preprint" },
+  };
+
+  const finding: CheckFinding = {
+    type: "version_changed",
+    message: "Published version available: 10.5678/published",
+    details: { newDoi: "10.5678/published" },
+  };
+
+  let items: CslItem[];
+  let library: {
+    find: ReturnType<typeof vi.fn>;
+    add: ReturnType<typeof vi.fn>;
+    getAll: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    save: ReturnType<typeof vi.fn>;
+  };
+
+  function useLibrary(initial: CslItem[]): void {
+    items = initial;
+    library = {
+      find: vi.fn(async (identifier: string, options?: { idType?: string }) =>
+        options?.idType === "doi"
+          ? items.find((i) => i.DOI === identifier)
+          : items.find((i) => i.id === identifier)
+      ),
+      add: vi.fn(async (item: CslItem) => {
+        const added = {
+          ...item,
+          id: "published-2025",
+          custom: { ...item.custom, uuid: "uuid-published" },
+        };
+        items.push(added);
+        return added;
+      }),
+      getAll: vi.fn(async () => items),
+      update: vi.fn(async (id: string, updates: Partial<CslItem>) => {
+        const index = items.findIndex((i) => i.id === id);
+        if (index === -1) return { updated: false };
+        const updated = {
+          ...items[index],
+          ...updates,
+          custom: { ...items[index]?.custom, ...updates.custom },
+        } as CslItem;
+        items[index] = updated;
+        return { updated: true, item: updated };
+      }),
+      save: vi.fn(async () => undefined),
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useLibrary([{ ...preprint }]);
+  });
+
+  it("adds the published version and points the preprint at it", async () => {
+    const { fetchDoi } = await import("../import/fetcher.js");
+    vi.mocked(fetchDoi).mockResolvedValueOnce({
+      success: true,
+      item: {
+        id: "ignored-id",
+        type: "article-journal",
+        title: "Published Title",
+        DOI: "10.5678/published",
+        "container-title": "Nature",
+        custom: { uuid: "ignored-uuid" },
+      },
+    });
+
+    const result = await applyFixAction(
+      library as never,
+      items[0] as CslItem,
+      finding,
+      "add_published_and_supersede"
+    );
+
+    expect(result.applied).toBe(true);
+    expect(result.message).toBe(
+      "Added published-2025 and marked preprint-2024 as superseded by it"
+    );
+    expect(items).toHaveLength(2);
+    expect(items[0]?.custom?.superseded_by).toBe("uuid-published");
+    expect(items[0]?.custom?.superseded_reason).toBe("published_version");
+  });
+
+  // Library.add generates a colliding-safe citation key and a uuid the pointer can target;
+  // carrying the fetched ones over would defeat both.
+  it("drops the fetched id and custom block before adding", async () => {
+    const { fetchDoi } = await import("../import/fetcher.js");
+    vi.mocked(fetchDoi).mockResolvedValueOnce({
+      success: true,
+      item: {
+        id: "ignored-id",
+        type: "article-journal",
+        title: "Published Title",
+        DOI: "10.5678/published",
+        custom: { uuid: "ignored-uuid" },
+      },
+    });
+
+    await applyFixAction(
+      library as never,
+      items[0] as CslItem,
+      finding,
+      "add_published_and_supersede"
+    );
+
+    const added = library.add.mock.calls[0]?.[0] as CslItem;
+    expect(added.id).toBeUndefined();
+    expect(added.custom).toBeUndefined();
+    expect(added.DOI).toBe("10.5678/published");
+  });
+
+  // Otherwise the fix would create exactly the duplicate this feature exists to resolve.
+  it("reuses a published version that is already in the library", async () => {
+    const existing: CslItem = {
+      id: "already-here",
+      type: "article-journal",
+      title: "Published Title",
+      DOI: "10.5678/published",
+      custom: { uuid: "uuid-existing" },
+    };
+    useLibrary([{ ...preprint }, existing]);
+
+    const { fetchDoi } = await import("../import/fetcher.js");
+
+    const result = await applyFixAction(
+      library as never,
+      items[0] as CslItem,
+      finding,
+      "add_published_and_supersede"
+    );
+
+    expect(result.applied).toBe(true);
+    expect(fetchDoi).not.toHaveBeenCalled();
+    expect(library.add).not.toHaveBeenCalled();
+    expect(items).toHaveLength(2);
+    expect(items[0]?.custom?.superseded_by).toBe("uuid-existing");
+  });
+
+  it("reports a fetch failure without touching the library", async () => {
+    const { fetchDoi } = await import("../import/fetcher.js");
+    vi.mocked(fetchDoi).mockResolvedValueOnce({ success: false, error: "404 Not Found" } as never);
+
+    const result = await applyFixAction(
+      library as never,
+      items[0] as CslItem,
+      finding,
+      "add_published_and_supersede"
+    );
+
+    expect(result.applied).toBe(false);
+    expect(result.message).toContain("Failed to fetch metadata for 10.5678/published");
+    expect(library.add).not.toHaveBeenCalled();
+  });
+
+  it("reports a finding with no published DOI", async () => {
+    const result = await applyFixAction(
+      library as never,
+      items[0] as CslItem,
+      { type: "version_changed", message: "Published version available" },
+      "add_published_and_supersede"
+    );
+
+    expect(result.applied).toBe(false);
+    expect(result.message).toBe("No published DOI available in finding details");
+  });
+
+  // The record was added even though the pointer could not be written; saying "nothing
+  // happened" would leave the user unaware of a new entry in their library.
+  it("says the record was added when the mark cannot be written", async () => {
+    const { fetchDoi } = await import("../import/fetcher.js");
+    vi.mocked(fetchDoi).mockResolvedValueOnce({
+      success: true,
+      item: { id: "x", type: "article-journal", title: "Published", DOI: "10.5678/published" },
+    });
+    // Make the preprint unreachable by id, so deprecateReference reports not_found
+    library.find = vi.fn(async (identifier: string, options?: { idType?: string }) =>
+      options?.idType === "doi" ? items.find((i) => i.DOI === identifier) : undefined
+    );
+
+    const result = await applyFixAction(
+      library as never,
+      items[0] as CslItem,
+      finding,
+      "add_published_and_supersede"
+    );
+
+    expect(result.applied).toBe(false);
+    expect(result.message).toContain("Added published-2025");
+    expect(result.message).toContain("could not mark preprint-2024 as superseded (not_found)");
+    expect(library.save).toHaveBeenCalled();
   });
 });

--- a/src/features/check/fix-actions.ts
+++ b/src/features/check/fix-actions.ts
@@ -7,6 +7,7 @@ export type FixActionType =
   | "add_retraction_note"
   | "remove_from_library"
   | "update_from_published"
+  | "add_published_and_supersede"
   | "add_version_tag"
   | "add_concern_tag"
   | "add_concern_note"
@@ -36,6 +37,13 @@ export function getFixActionsForFinding(finding: CheckFinding): FixAction[] {
       ];
     case "version_changed":
       return [
+        // Listed first: overwriting in place changes what the existing citation key resolves
+        // to, which breaks a manuscript already citing the preprint. Adding the published
+        // version alongside and forwarding the old record keeps both working (#108).
+        {
+          type: "add_published_and_supersede",
+          label: "Add published version as a new record, supersede this one",
+        },
         { type: "update_from_published", label: "Update metadata from published version" },
         { type: "add_version_tag", label: 'Add tag "has-published-version"' },
         { type: "skip", label: "Skip" },
@@ -132,6 +140,64 @@ async function applyUpdateFromPublished(
   return { applied: true, message: `Updated metadata from ${newDoi}` };
 }
 
+/**
+ * Add the published version as its own record and point the old one at it.
+ *
+ * The alternative action overwrites the existing record in place, which silently changes what
+ * the preprint's citation key resolves to. This keeps both records: the manuscript citing the
+ * preprint still resolves, and every read command reports where to cite instead (#108).
+ */
+async function applyAddPublishedAndSupersede(
+  library: ILibrary,
+  item: CslItem,
+  finding: CheckFinding
+): Promise<FixActionResult> {
+  const newDoi = finding.details?.newDoi;
+  if (!newDoi) {
+    return { applied: false, message: "No published DOI available in finding details" };
+  }
+
+  // The published version may already have been imported separately — reuse it rather than
+  // adding a second copy, which would just create the duplicate this feature exists to resolve.
+  let published = await library.find(newDoi, { idType: "doi" });
+
+  if (!published) {
+    const { fetchDoi } = await import("../import/fetcher.js");
+    const fetchResult = await fetchDoi(newDoi);
+    if (!fetchResult.success) {
+      return {
+        applied: false,
+        message: `Failed to fetch metadata for ${newDoi}: ${fetchResult.error}`,
+      };
+    }
+    // Drop the fetched id and custom block: Library.add generates a citation key that cannot
+    // collide, and a uuid the superseded pointer can target.
+    const { id: _id, custom: _custom, ...metadata } = fetchResult.item;
+    published = await library.add(metadata as CslItem);
+  }
+
+  const { deprecateReference } = await import("../operations/deprecate.js");
+  const outcome = await deprecateReference(library, {
+    identifier: item.id,
+    target: published.id,
+    reason: "published_version",
+  });
+
+  if (!outcome.applied) {
+    // The new record is already in the library, so say so rather than implying nothing happened
+    await library.save();
+    return {
+      applied: false,
+      message: `Added ${published.id}, but could not mark ${item.id} as superseded (${outcome.errorType ?? "unknown"})`,
+    };
+  }
+
+  return {
+    applied: true,
+    message: `Added ${published.id} and marked ${item.id} as superseded by it`,
+  };
+}
+
 async function applyUpdateAllFields(
   library: ILibrary,
   item: CslItem,
@@ -212,6 +278,9 @@ export async function applyFixAction(
 
     case "update_from_published":
       return applyUpdateFromPublished(library, item, finding);
+
+    case "add_published_and_supersede":
+      return applyAddPublishedAndSupersede(library, item, finding);
 
     case "update_all_fields":
       return applyUpdateAllFields(library, item, finding);


### PR DESCRIPTION
## Summary

Final PR for #108. Covers issue case 2: a preprint kept alongside its published version.

`check` already detects `version_changed` from Crossref's `update-to` relation, but its only fix options were "overwrite this record's metadata in place, keeping the citation key" and "add a tag". Neither works when you hold the preprint and the published article as separate records — and the in-place update is actively unsafe for a manuscript already citing the preprint's key, which would then render the published article under a key that no longer describes it.

This adds `add_published_and_supersede`, listed **first** among the `version_changed` actions:

```
[VERSION] preprint-2024: Published version available: 10.5678/published
> Add published version as a new record, supersede this one
  Update metadata from published version
  Add tag "has-published-version"
  Skip
```

```
Added published-2025 and marked preprint-2024 as superseded by it
```

Both records stay: the manuscript citing the preprint still resolves, and `show` / `cite` / `search` / `export` report where to cite instead.

## Details

**An already-present published DOI is reused.** If the published version was imported separately at some point, the action points at that record rather than fetching and adding a second copy — otherwise the fix would create exactly the duplicate `ref duplicates` exists to resolve.

**The fetched `id` and `custom` block are dropped before `library.add`**, so the new record gets a collision-checked citation key and a uuid the superseded pointer can target.

**A partial failure reports what actually happened.** If the record is added but the mark cannot be written (the preprint moved or was renamed between the check and the fix), the result says "Added published-2025, but could not mark preprint-2024 as superseded (…)" and still saves — reporting a plain failure would leave the user unaware of a new entry in their library.

Marking goes through `deprecateReference`, so the successor-exists and cycle checks apply here too.

## Verification

- `npm test` — 190 files, 3740 passed, 0 failed (6 new tests on this action)
- `./test-fixtures/test-superseded.sh` — 36/36
- `npm run lint`, `npm run typecheck`, `npm run build` — clean

## #108 as a whole

| PR | Case addressed |
|----|----------------|
| #110 | Data model, `ref deprecate`, reference-time reporting — conference → journal, by hand |
| #112 | `ref duplicates` retroactive scan — import duplicates (36 pairs in the maintainer's library) |
| #113 (this) | `check --fix` — preprint → published |

Two deviations from the issue's proposal, both argued in the earlier PRs: `superseded_by` stores the successor's **UUID** rather than its citation key (keys are renamed by collision resolution), and `export --all` **keeps** superseded records with a warning rather than excluding them (excluding would turn a warning into a failed bibliography build).

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mau1bJxTcehVb9sWexf8L9