### PR TITLE
fix(mcp): superseded escape hatch and citable successor for agents (#108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     The suggestion ranks by metadata completeness, then publication year — the ordering that
     separates an online-first record from its version of record
 
+- **MCP superseded handling** (#108): the `list` tool omits superseded references and gains an
+  `includeSuperseded` parameter to get them back, matching `ref list`; the `show` tool resolves
+  the pointer to a citation key so an agent sees something it can cite rather than a bare uuid
+
 - **`check --fix` can keep both versions** (#108): `version_changed` findings gain an
   `add_published_and_supersede` action that adds the published version as a new record and marks
   the preprint as superseded by it

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ With a custom library:
 | Tool | Description | Parameters |
 |------|-------------|------------|
 | `search` | Search references by query | `query`: Search string (e.g., `"author:smith 2024"`) |
-| `list` | List all references | `format?`: `"json"` \| `"bibtex"` \| `"pretty"` |
+| `list` | List all references (superseded ones omitted) | `format?`: `"json"` \| `"bibtex"` \| `"pretty"`, `includeSuperseded?`: Include deprecated records |
 | `add` | Add new reference(s) | `input`: DOI, PMID, ISBN, BibTeX, RIS, or CSL-JSON |
 | `remove` | Remove a reference | `id`: Reference ID, `force`: must be `true` |
 | `cite` | Generate formatted citation | `ids`: Array of reference IDs, `style?`: Citation style, `format?`: `"text"` \| `"html"` |

--- a/spec/features/superseded.md
+++ b/spec/features/superseded.md
@@ -108,6 +108,10 @@ Dangling and self-terminating cases:
 | `list` | Superseded records are **hidden**; `--include-superseded` shows them (and warns) |
 | `export` | Records are **included**; warn per record plus a summary line |
 
+The MCP server mirrors this: the `list` tool omits superseded references unless
+`includeSuperseded` is passed, and the `show` tool resolves the pointer to a citation key so an
+agent sees something it can cite rather than a bare uuid.
+
 ### Why `list` hides but `export` does not
 
 `list` is a browsing command — a superseded record is noise once its successor exists.

--- a/src/mcp/tools/list.test.ts
+++ b/src/mcp/tools/list.test.ts
@@ -153,3 +153,88 @@ describe("MCP list tool", () => {
     });
   });
 });
+
+describe("MCP list tool superseded handling", () => {
+  let tempDir: string;
+  let libraryOperations: ILibraryOperations;
+
+  /** Capture the tool callback the way the other tests in this file do. */
+  async function callList(
+    args: ListToolParams
+  ): Promise<{ total: number; items: { id: string }[] }> {
+    let capturedCallback:
+      | ((args: ListToolParams) => Promise<{ content: Array<{ text: string }> }>)
+      | undefined;
+    const mockServer = {
+      registerTool: (_name: string, _config: unknown, cb: NonNullable<typeof capturedCallback>) => {
+        capturedCallback = cb;
+      },
+    };
+    registerListTool(mockServer as never, () => libraryOperations, getConfig);
+    const result = await capturedCallback?.(args);
+    return JSON.parse(result?.content[0]?.text ?? "{}");
+  }
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-list-superseded-"));
+    const libraryPath = path.join(tempDir, "references.json");
+    await fs.writeFile(
+      libraryPath,
+      JSON.stringify([
+        {
+          id: "Carless2023-yt",
+          type: "article-journal",
+          title: "Version of record",
+          custom: {
+            uuid: "22222222-2222-4222-8222-222222222222",
+            created_at: "2026-01-01T00:00:00.000Z",
+            timestamp: "2026-01-01T00:00:00.000Z",
+          },
+        },
+        {
+          id: "Carless2020-yj",
+          type: "article-journal",
+          title: "Online first",
+          custom: {
+            uuid: "11111111-1111-4111-8111-111111111111",
+            created_at: "2026-01-01T00:00:00.000Z",
+            timestamp: "2026-01-01T00:00:00.000Z",
+            superseded_by: "22222222-2222-4222-8222-222222222222",
+            superseded_reason: "duplicate",
+            superseded_at: "2026-08-07T00:00:00.000Z",
+          },
+        },
+      ]),
+      "utf-8"
+    );
+    libraryOperations = new OperationsLibrary(await Library.load(libraryPath));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("omits superseded references by default", async () => {
+    const response = await callList({});
+
+    expect(response.items.map((i) => i.id)).toEqual(["Carless2023-yt"]);
+    expect(response.total).toBe(1);
+  });
+
+  // An agent that needs the full library must have a way to ask for it.
+  it("includes them with includeSuperseded", async () => {
+    const response = await callList({ includeSuperseded: true });
+
+    expect(response.items.map((i) => i.id).sort()).toEqual(["Carless2020-yj", "Carless2023-yt"]);
+    expect(response.total).toBe(2);
+  });
+
+  it("carries the pointer through so the agent can follow it", async () => {
+    const response = await callList({ includeSuperseded: true });
+    const superseded = response.items.find((i) => i.id === "Carless2020-yj") as {
+      custom?: { superseded_by?: string };
+    };
+
+    expect(superseded.custom?.superseded_by).toBe("22222222-2222-4222-8222-222222222222");
+  });
+});

--- a/src/mcp/tools/list.ts
+++ b/src/mcp/tools/list.ts
@@ -15,6 +15,7 @@ export interface ListToolParams {
   order?: SortOrder | undefined;
   limit?: number | undefined;
   offset?: number | undefined;
+  includeSuperseded?: boolean | undefined;
 }
 
 /**
@@ -33,7 +34,9 @@ export function registerListTool(
     "list",
     {
       description:
-        "List references in the library. Returns raw CslItem[] data. Supports sorting and pagination.",
+        "List references in the library. Returns raw CslItem[] data. Supports sorting and " +
+        "pagination. References marked as superseded (custom.superseded_by) are omitted unless " +
+        "includeSuperseded is set — cite the successor instead.",
       inputSchema: {
         sort: sortFieldSchema
           .optional()
@@ -51,6 +54,13 @@ export function registerListTool(
           .min(0)
           .optional()
           .describe("Number of results to skip (default: 0)"),
+        includeSuperseded: z
+          .boolean()
+          .optional()
+          .describe(
+            "Include references marked as superseded by another (default: false). " +
+              "Their custom.superseded_by holds the successor's uuid."
+          ),
       },
     },
     async (args: ListToolParams) => {
@@ -62,7 +72,7 @@ export function registerListTool(
 
       const result = await libraryOps.list({
         limit,
-        ...pickDefined(args, ["sort", "order", "offset"] as const),
+        ...pickDefined(args, ["sort", "order", "offset", "includeSuperseded"] as const),
       });
 
       return {

--- a/src/mcp/tools/show.ts
+++ b/src/mcp/tools/show.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 import type { Config } from "../../config/schema.js";
 import { normalizeReference } from "../../features/format/show-normalizer.js";
 import type { ILibraryOperations } from "../../features/operations/library-operations.js";
+import { isSuperseded } from "../../features/superseded/index.js";
 
 interface ShowToolParams {
   identifier?: string | undefined;
@@ -48,7 +49,13 @@ export function createShowToolHandler(
     }
 
     const attachmentsDir = config.attachments?.directory;
-    const normalizeOpts = attachmentsDir ? { attachmentsDirectory: attachmentsDir } : undefined;
+    // Resolve the successor pointer to a citation key. Without the library, `superseded` stays
+    // null and the agent would only see a bare uuid under raw.custom, which it cannot cite.
+    const allItems = isSuperseded(item) ? await libraryOps.getAll() : undefined;
+    const normalizeOpts = {
+      ...(attachmentsDir && { attachmentsDirectory: attachmentsDir }),
+      ...(allItems && { allItems }),
+    };
     const normalized = normalizeReference(item, normalizeOpts);
 
     return {


### PR DESCRIPTION
## Summary

Two gaps the CLI-focused work on #108 left in the MCP surface. Found while checking whether anything remained before cutting a release.

**`list` silently dropped records with no way back.** PR #110 added the superseded filter to `listReferences`, which the MCP `list` tool goes through — so an agent stopped seeing those references and had no parameter to ask for them. That is a behaviour change to an existing tool contract shipped without its escape hatch. Adds `includeSuperseded`, matching `ref list --include-superseded`, and says so in the tool description so an agent knows the omission is deliberate.

**`show` gave the agent a uuid it cannot cite.** The tool called `normalizeReference` without the library, so `superseded` stayed null and the only trace was a bare `superseded_by` uuid under `raw.custom`. Now passes the library so the pointer resolves to a citation key — fetched only when the record is actually marked, so unmarked lookups cost nothing extra.

## Verification

- `npm test` — 190 files, 3743 passed, 0 failed (3 new tests on MCP list)
- `npm run lint`, `npm run typecheck` — clean

## Still open for a later decision

There are no MCP tools for `deprecate` or `duplicates`. Not every CLI command has one (`export`, `url`, `config` do not either), so this is a scope call rather than an omission — but an agent auditing citation keys in a manuscript is arguably the main consumer of both. Worth a separate issue if you want them.

Refs #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mau1bJxTcehVb9sWexf8L9